### PR TITLE
fix: use optimistic locking to update existing objects to avoid racing unseen modifications to objects past the comparator

### DIFF
--- a/machinery/objects.go
+++ b/machinery/objects.go
@@ -274,6 +274,12 @@ func (e *ObjectEngine) objectUpdateHandling(
 		), nil
 	}
 
+	// Use optimistic locking to ensure that object will only
+	// be overridden when previous state is known to us.
+	// This prevents re-adoption of orphaned objects where we
+	// haven't observed the orphaning yet.
+	desiredObject.SetResourceVersion(actualObject.GetResourceVersion())
+
 	switch ctrlSit {
 	case ctrlSituationIsController:
 		modified := compareRes.Comparison != nil &&


### PR DESCRIPTION
Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

Use optimistic locking by specifying resourceVersion of existing object as observed in our client-side cache.
This change ensures that no modifications to an object are actually written when it contains modifications that we are not aware about yet.

A critical (and the only) example of this I am aware about is: orphaning of managed resources where we would just re-adopt the object because we are not aware of the need for adoption.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
