### PR TITLE
OPRUN-4047: Handle /status subresource in comperator

### DIFF
--- a/machinery/testdata/schemas.json
+++ b/machinery/testdata/schemas.json
@@ -1,4 +1,7 @@
 {
+  "paths": {
+    "/api/v1/namespaces/{namespace}/pods/{name}/status": {}
+  },
   "components": {
     "schemas": {
       "io.k8s.api.core.v1.Pod": {

--- a/test/comparator_test.go
+++ b/test/comparator_test.go
@@ -224,22 +224,6 @@ Comparison:
   .spec.template.spec.containers[name="app"].imagePullPolicy
   .spec.template.spec.containers[name="app"].terminationMessagePath
   .spec.template.spec.containers[name="app"].terminationMessagePolicy
-  .status.observedGeneration
-  .status.replicas
-  .status.unavailableReplicas
-  .status.updatedReplicas
-  .status.conditions[type="Available"].lastTransitionTime
-  .status.conditions[type="Available"].lastUpdateTime
-  .status.conditions[type="Available"].message
-  .status.conditions[type="Available"].reason
-  .status.conditions[type="Available"].status
-  .status.conditions[type="Available"].type
-  .status.conditions[type="Progressing"].lastTransitionTime
-  .status.conditions[type="Progressing"].lastUpdateTime
-  .status.conditions[type="Progressing"].message
-  .status.conditions[type="Progressing"].reason
-  .status.conditions[type="Progressing"].status
-  .status.conditions[type="Progressing"].type
 - Modified:
   .spec.template.spec.containers[name="app"].image
 `,
@@ -296,22 +280,6 @@ Comparison:
   .spec.template.spec.containers[name="app"].imagePullPolicy
   .spec.template.spec.containers[name="app"].terminationMessagePath
   .spec.template.spec.containers[name="app"].terminationMessagePolicy
-  .status.observedGeneration
-  .status.replicas
-  .status.unavailableReplicas
-  .status.updatedReplicas
-  .status.conditions[type="Available"].lastTransitionTime
-  .status.conditions[type="Available"].lastUpdateTime
-  .status.conditions[type="Available"].message
-  .status.conditions[type="Available"].reason
-  .status.conditions[type="Available"].status
-  .status.conditions[type="Available"].type
-  .status.conditions[type="Progressing"].lastTransitionTime
-  .status.conditions[type="Progressing"].lastUpdateTime
-  .status.conditions[type="Progressing"].message
-  .status.conditions[type="Progressing"].reason
-  .status.conditions[type="Progressing"].status
-  .status.conditions[type="Progressing"].type
 - Modified:
   .spec.replicas
   .spec.template.spec.containers[name="app"].image
@@ -387,22 +355,6 @@ Comparison:
   .spec.template.spec.containers[name="app"].imagePullPolicy
   .spec.template.spec.containers[name="app"].terminationMessagePath
   .spec.template.spec.containers[name="app"].terminationMessagePolicy
-  .status.observedGeneration
-  .status.replicas
-  .status.unavailableReplicas
-  .status.updatedReplicas
-  .status.conditions[type="Available"].lastTransitionTime
-  .status.conditions[type="Available"].lastUpdateTime
-  .status.conditions[type="Available"].message
-  .status.conditions[type="Available"].reason
-  .status.conditions[type="Available"].status
-  .status.conditions[type="Available"].type
-  .status.conditions[type="Progressing"].lastTransitionTime
-  .status.conditions[type="Progressing"].lastUpdateTime
-  .status.conditions[type="Progressing"].message
-  .status.conditions[type="Progressing"].reason
-  .status.conditions[type="Progressing"].status
-  .status.conditions[type="Progressing"].type
 - Modified:
   .spec.replicas
   .spec.template.spec.containers[name="app"].image


### PR DESCRIPTION
When an object has the /status subresource defined, the kube-apiserver will automatically drop updates to the objects .status. If boxcutter is input if with an object that has .status set, it will try to reconcile the object every time as a "Recovered" action.

To fix this problem, this commit adds a check for the status subresource and strips .status from the comparitor inputs if it is defined.

### Change Type

Bug Fix

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
