### PR TITLE
refactor: fix typo in InTransition

### DIFF
--- a/machinery/phases.go
+++ b/machinery/phases.go
@@ -221,7 +221,7 @@ type PhaseResult interface {
 	// InTransition returns true if the Phase has not yet fully rolled out,
 	// if the phase has objects progressed to a new revision or
 	// if objects have unresolved conflicts.
-	InTransistion() bool
+	InTransition() bool
 	// IsComplete returns true when all objects have
 	// successfully been reconciled and pass their probes.
 	IsComplete() bool
@@ -256,7 +256,7 @@ func (r *phaseResult) GetObjects() []ObjectResult {
 // InTransition returns true if the Phase has not yet fully rolled out,
 // if the phase has some objects progressed to a new revision or
 // if objects have unresolved conflicts.
-func (r *phaseResult) InTransistion() bool {
+func (r *phaseResult) InTransition() bool {
 	if err := r.GetValidationError(); err != nil {
 		return false
 	}
@@ -308,7 +308,7 @@ func (r *phaseResult) IsComplete() bool {
 func (r *phaseResult) String() string {
 	out := fmt.Sprintf(
 		"Phase %q\nComplete: %t\nIn Transition: %t\n",
-		r.name, r.IsComplete(), r.InTransistion(),
+		r.name, r.IsComplete(), r.InTransition(),
 	)
 
 	if err := r.GetValidationError(); err != nil {

--- a/machinery/phases_test.go
+++ b/machinery/phases_test.go
@@ -197,7 +197,7 @@ func (m *phaseValidatorMock) Validate(
 
 func TestPhaseResult(t *testing.T) {
 	t.Parallel()
-	t.Run("InTransistion", func(t *testing.T) {
+	t.Run("InTransition", func(t *testing.T) {
 		t.Parallel()
 
 		tests := []struct {
@@ -251,7 +251,7 @@ func TestPhaseResult(t *testing.T) {
 				pr := &phaseResult{
 					objects: test.res,
 				}
-				assert.Equal(t, test.expected, pr.InTransistion())
+				assert.Equal(t, test.expected, pr.InTransition())
 			})
 		}
 	})

--- a/machinery/revision.go
+++ b/machinery/revision.go
@@ -64,7 +64,7 @@ type RevisionResult interface {
 	// InTransition returns true if the Phase has not yet fully rolled out,
 	// if the phase has objects progressed to a new revision or
 	// if objects have unresolved conflicts.
-	InTransistion() bool
+	InTransition() bool
 	// IsComplete returns true when all objects have
 	// successfully been reconciled and pass their probes.
 	IsComplete() bool
@@ -88,9 +88,9 @@ func (r *revisionResult) GetValidationError() *validation.RevisionValidationErro
 // InTransition returns true if the Phase has not yet fully rolled out,
 // if the phase has objects progressed to a new revision or
 // if objects have unresolved conflicts.
-func (r *revisionResult) InTransistion() bool {
+func (r *revisionResult) InTransition() bool {
 	for _, p := range r.phasesResults {
-		if p.InTransistion() {
+		if p.InTransition() {
 			return true
 		}
 	}
@@ -145,7 +145,7 @@ func (r *revisionResult) GetPhases() []PhaseResult {
 func (r *revisionResult) String() string {
 	out := fmt.Sprintf(
 		"Revision\nComplete: %t\nIn Transition: %t\n",
-		r.IsComplete(), r.InTransistion(),
+		r.IsComplete(), r.InTransition(),
 	)
 
 	if err := r.GetValidationError(); err != nil {

--- a/test/revision_engine_basic_test.go
+++ b/test/revision_engine_basic_test.go
@@ -99,7 +99,7 @@ func TestRevisionEngine(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.False(t, res.IsComplete(), "Revision should not be complete.")
-	assert.True(t, res.InTransistion(), "Revision should be in transition.")
+	assert.True(t, res.InTransition(), "Revision should be in transition.")
 
 	cm := &corev1.ConfigMap{}
 	require.NoError(t, Client.Get(
@@ -117,7 +117,7 @@ func TestRevisionEngine(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, res.IsComplete(), "Revision should be complete.")
-	assert.False(t, res.InTransistion(), "Revision should not be in transition.")
+	assert.False(t, res.InTransition(), "Revision should not be in transition.")
 	assert.NoError(t, Client.Get(ctx, client.ObjectKey{Name: "test-rev-obj-1", Namespace: "default"}, cm),
 		"test-rev-obj-1 should have been created")
 	assert.NoError(t, Client.Get(ctx, client.ObjectKey{Name: "test-rev-obj-2", Namespace: "default"}, cm),

--- a/test/revision_engine_colision_protection_test.go
+++ b/test/revision_engine_colision_protection_test.go
@@ -53,7 +53,7 @@ func TestCollisionProtectionPreventUnowned(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.False(t, res.IsComplete())
-	assert.True(t, res.InTransistion())
+	assert.True(t, res.InTransition())
 
 	phases := res.GetPhases()
 	require.Len(t, phases, 1)
@@ -105,7 +105,7 @@ func TestCollisionProtectionPreventOwned(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.False(t, res.IsComplete())
-	assert.True(t, res.InTransistion())
+	assert.True(t, res.InTransition())
 	require.Len(t, res.GetPhases(), 1)
 	phase := res.GetPhases()[0]
 	require.Len(t, phase.GetObjects(), 1)

--- a/test/revision_engine_preflight_validation_test.go
+++ b/test/revision_engine_preflight_validation_test.go
@@ -63,7 +63,7 @@ func TestWithOwnerReference(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.False(t, res.IsComplete())
-			assert.False(t, res.InTransistion())
+			assert.False(t, res.InTransition())
 
 			var objValErr validation.ObjectValidationError
 


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
Fixes a typo in the `InTransition` method of the `RevisionResult` and `PhaseResult` intefaces

### Change Type

This is a `Breaking Change` as it modifies the method name for publicly available APIs/interfaces:
- RevisionResult.InTransition
- PhaseResult.InTransition


<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
