### PR TITLE
Add WithOrphan option to allow excluding objects from teardown

### DIFF
--- a/machinery/objects.go
+++ b/machinery/objects.go
@@ -109,7 +109,7 @@ func (e *ObjectEngine) Teardown(
 	// Shortcut when Owner is orphaning its dependents.
 	// If we don't check this, we might be too quick and start deleting
 	// dependents that should be kept on the cluster!
-	if controllerutil.ContainsFinalizer(owner, "orphan") {
+	if controllerutil.ContainsFinalizer(owner, "orphan") || options.Orphan {
 		err := removeBoxcutterManagedLabel(ctx, e.writer, desiredObject.(*unstructured.Unstructured))
 		if err != nil {
 			return false, err


### PR DESCRIPTION
### Summary
`WithOrphan` excludes objects from Teardown.
use it as `WithObjectTeardownOptions(obj, WithOrphan())` to exclude individual objects or
use it as `WithPhaseTeardownOptions("my-phase", WithOrphan()) `to exclude a whole phase.

### Change Type

New Feature

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
