### PR TITLE
(feat): add WithTeardownWriter option to teardown

### DIFF
--- a/machinery/objects.go
+++ b/machinery/objects.go
@@ -155,7 +155,12 @@ func (e *ObjectEngine) Teardown(
 	}
 
 	// Actually delete the object.
-	err = e.writer.Delete(ctx, desiredObject, client.Preconditions{
+	writer := e.writer
+	if options.TeardownWriter != nil {
+		writer = options.TeardownWriter
+	}
+
+	err = writer.Delete(ctx, desiredObject, client.Preconditions{
 		UID:             ptr.To(actualObject.GetUID()),
 		ResourceVersion: ptr.To(actualObject.GetResourceVersion()),
 	})

--- a/machinery/types/options.go
+++ b/machinery/types/options.go
@@ -124,11 +124,13 @@ var (
 	_ ObjectReconcileOption = (WithPaused{})
 	_ ObjectReconcileOption = (WithPreviousOwners{})
 	_ ObjectReconcileOption = (WithProbe("", nil))
+	_ ObjectTeardownOption  = (WithTeardownWriter(nil))
 )
 
 // ObjectTeardownOptions holds configuration options changing object teardown.
 type ObjectTeardownOptions struct {
-	Orphan bool
+	Orphan         bool
+	TeardownWriter client.Writer
 }
 
 // Default sets empty Option fields to their default value.
@@ -235,6 +237,15 @@ func WithOrphan() ObjectTeardownOption {
 	return &teardownOptionFn{
 		fn: func(opts *ObjectTeardownOptions) {
 			opts.Orphan = true
+		},
+	}
+}
+
+// WithTeardownWriter tears down the revision with the given writer.
+func WithTeardownWriter(writer client.Writer) ObjectTeardownOption {
+	return &teardownOptionFn{
+		fn: func(opts *ObjectTeardownOptions) {
+			opts.TeardownWriter = writer
 		},
 	}
 }


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

This PR adds a new option to the object teardown method that allow the user to override the revision engine's writer during teardown. This is useful in cases where the revision engine uses a scoped client that depends on the existence of RBAC resources on the cluster in order to function appropriately. In a teardown scenario, where all resources are deleted concurrently, this allows users to accomplish teardown with a client that lives longer than the revision.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
