### PR TITLE
PKO-386: Update golangci-lint to 2.9.0

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -91,7 +91,6 @@ linters:
     - protogetter
     - reassign
     - recvcheck
-    - revive
     - rowserrcheck
     - sloglint
     - spancheck
@@ -110,9 +109,13 @@ linters:
     - usetesting
     - wastedassign
     - whitespace
-    - wsl
+    - wsl_v5
     - zerologlint
   settings:
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
     gosec:
       excludes:
         - G301

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	err := errors.Join(
 		mgr.RegisterGoTool("gotestfmt", "github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt", "2.5.0"),
-		mgr.RegisterGoTool("golangci-lint", "github.com/golangci/golangci-lint/v2/cmd/golangci-lint", "2.1.6"),
+		mgr.RegisterGoTool("golangci-lint", "github.com/golangci/golangci-lint/v2/cmd/golangci-lint", "2.9.0"),
 		mgr.Register(&Dev{}, &CI{}),
 	)
 	if err != nil {

--- a/cmd/reference/internal/deploy.go
+++ b/cmd/reference/internal/deploy.go
@@ -427,10 +427,12 @@ func (c *Reconciler) toRevision(deployName string, cm *corev1.ConfigMap) (
 				if obj.GetObjectKind().GroupVersionKind().Kind != "ConfigMap" || !ok {
 					return probing.TrueResult()
 				}
+
 				f, ok, _ := unstructured.NestedString(u.Object, "data", "continue")
 				if !ok {
 					return probing.FalseResult(".data.continue not set")
 				}
+
 				if f != "yes" {
 					return probing.FalseResult(`.data.continue not set to "yes"`)
 				}

--- a/cmd/reference/main.go
+++ b/cmd/reference/main.go
@@ -23,6 +23,7 @@ func main() {
 	ref := internal.NewReference(ourScheme, ctrl.GetConfigOrDie())
 	if err := ref.Start(ctrl.SetupSignalHandler()); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, "crashed: ", err)
+
 		os.Exit(1)
 	}
 }

--- a/machinery/objects.go
+++ b/machinery/objects.go
@@ -478,12 +478,12 @@ func (e *ObjectEngine) apply(
 		return err
 	}
 
-	o := []client.ApplyOption{
-		client.FieldOwner(e.fieldOwner),
-	}
+	o := make([]client.ApplyOption, 0, len(opts)+1)
+	o = append(o, client.FieldOwner(e.fieldOwner))
 	o = append(o, opts...)
 
 	var ac runtime.ApplyConfiguration
+
 	switch v := obj.(type) {
 	case runtime.ApplyConfiguration:
 		ac = v

--- a/machinery/objects_test.go
+++ b/machinery/objects_test.go
@@ -424,6 +424,7 @@ func TestObjectEngine(t *testing.T) {
 						*obj = *actualObject
 					}).
 					Return(nil)
+
 				fs := &fieldpath.Set{}
 				fs.Insert(fieldpath.MakePathOrDie("spec", "banana"))
 				ddm.
@@ -524,6 +525,7 @@ func TestObjectEngine(t *testing.T) {
 						*obj = *actualObject
 					}).
 					Return(nil)
+
 				fs := &fieldpath.Set{}
 				fs.Insert(fieldpath.MakePathOrDie("spec", "banana"))
 				ddm.
@@ -622,6 +624,7 @@ func TestObjectEngine(t *testing.T) {
 						*obj = *actualObject
 					}).
 					Return(nil)
+
 				fs := &fieldpath.Set{}
 				fs.Insert(fieldpath.MakePathOrDie("spec", "banana"))
 				ddm.
@@ -715,6 +718,7 @@ func TestObjectEngine(t *testing.T) {
 						*obj = *actualObject
 					}).
 					Return(nil)
+
 				fs := &fieldpath.Set{}
 				fs.Insert(fieldpath.MakePathOrDie("spec", "banana"))
 				ddm.
@@ -806,6 +810,7 @@ func TestObjectEngine(t *testing.T) {
 						*obj = *actualObject
 					}).
 					Return(nil)
+
 				fs := &fieldpath.Set{}
 				fs.Insert(fieldpath.MakePathOrDie("spec", "banana"))
 				ddm.
@@ -852,7 +857,6 @@ func TestObjectEngine(t *testing.T) {
 
 			test.mockSetup(cache, writer, divergeDetector)
 
-			//nolint:usetesting
 			ctx := context.Background()
 			res, err := oe.Reconcile(
 				ctx, owner, 1, test.desiredObject,
@@ -981,7 +985,6 @@ func TestObjectEngine_Reconcile_UnsupportedTypedObject(t *testing.T) {
 				},
 			}, nil)
 
-		//nolint:usetesting
 		ctx := context.Background()
 		res, err := oe.Reconcile(ctx, owner, 1, desiredObject)
 

--- a/machinery/phases.go
+++ b/machinery/phases.go
@@ -87,23 +87,26 @@ type phaseTeardownResult struct {
 }
 
 func (r *phaseTeardownResult) String() string {
-	out := fmt.Sprintf("Phase %q\n", r.name)
+	var out strings.Builder
+	fmt.Fprintf(&out, "Phase %q\n", r.name)
 
 	if len(r.gone) > 0 {
-		out += "Gone Objects:\n"
+		fmt.Fprintln(&out, "Gone Objects:")
+
 		for _, gone := range r.gone {
-			out += "- " + gone.String() + "\n"
+			fmt.Fprintf(&out, "- %s\n", gone.String())
 		}
 	}
 
 	if len(r.waiting) > 0 {
-		out += "Waiting Objects:\n"
+		fmt.Fprintln(&out, "Waiting Objects:")
+
 		for _, waiting := range r.waiting {
-			out += "- " + waiting.String() + "\n"
+			fmt.Fprintf(&out, "- %s\n", waiting.String())
 		}
 	}
 
-	return out
+	return out.String()
 }
 
 func (r *phaseTeardownResult) GetName() string {
@@ -306,22 +309,25 @@ func (r *phaseResult) IsComplete() bool {
 }
 
 func (r *phaseResult) String() string {
-	out := fmt.Sprintf(
+	var out strings.Builder
+	fmt.Fprintf(&out,
 		"Phase %q\nComplete: %t\nIn Transition: %t\n",
 		r.name, r.IsComplete(), r.InTransition(),
 	)
 
 	if err := r.GetValidationError(); err != nil {
-		out += "Validation Errors:\n"
+		fmt.Fprintln(&out, "Validation Errors:")
+
 		for _, err := range err.Unwrap() {
-			out += "- " + err.Error() + "\n"
+			fmt.Fprintf(&out, "- %s\n", err.Error())
 		}
 	}
 
-	out += "Objects:\n"
+	fmt.Fprintln(&out, "Objects:")
+
 	for _, ores := range r.objects {
-		out += "- " + strings.ReplaceAll(strings.TrimSpace(ores.String()), "\n", "\n  ") + "\n"
+		fmt.Fprintf(&out, "- %s\n", strings.ReplaceAll(strings.TrimSpace(ores.String()), "\n", "\n  "))
 	}
 
-	return out
+	return out.String()
 }

--- a/machinery/revision.go
+++ b/machinery/revision.go
@@ -143,24 +143,27 @@ func (r *revisionResult) GetPhases() []PhaseResult {
 }
 
 func (r *revisionResult) String() string {
-	out := fmt.Sprintf(
+	var out strings.Builder
+	fmt.Fprintf(&out,
 		"Revision\nComplete: %t\nIn Transition: %t\n",
 		r.IsComplete(), r.InTransition(),
 	)
 
 	if err := r.GetValidationError(); err != nil {
-		out += "Validation Errors:\n"
+		fmt.Fprintln(&out, "Validation Errors:")
+
 		for _, err := range err.Unwrap() {
-			out += "- " + err.Error() + "\n"
+			fmt.Fprintf(&out, "- %s\n", err.Error())
 		}
 	}
 
 	phasesWithResults := map[string]struct{}{}
-	out += "Phases:\n"
+
+	fmt.Fprintln(&out, "Phases:")
 
 	for _, ores := range r.phasesResults {
 		phasesWithResults[ores.GetName()] = struct{}{}
-		out += "- " + strings.TrimSpace(strings.ReplaceAll(ores.String(), "\n", "\n  ")) + "\n"
+		fmt.Fprintf(&out, "- %s\n", strings.TrimSpace(strings.ReplaceAll(ores.String(), "\n", "\n  ")))
 	}
 
 	for _, p := range r.phases {
@@ -168,10 +171,10 @@ func (r *revisionResult) String() string {
 			continue
 		}
 
-		out += fmt.Sprintf("- Phase %q (Pending)\n", p)
+		fmt.Fprintf(&out, "- Phase %q (Pending)\n", p)
 	}
 
-	return out
+	return out.String()
 }
 
 // Reconcile runs actions to bring actual state closer to desired.
@@ -279,34 +282,39 @@ func (r *revisionTeardownResult) GetGonePhaseNames() []string {
 }
 
 func (r *revisionTeardownResult) String() string {
-	out := fmt.Sprintf(
-		"Revision Teardown\nActive: %s\n",
-		r.active,
-	)
+	var out strings.Builder
+	fmt.Fprintln(&out, "Revision Teardown")
+
+	if len(r.active) > 0 {
+		fmt.Fprintf(&out, "Active: %s\n", r.active)
+	}
 
 	if len(r.waiting) > 0 {
-		out += "Waiting Phases:\n"
+		fmt.Fprintln(&out, "Waiting Phases:")
+
 		for _, waiting := range r.waiting {
-			out += "- " + waiting + "\n"
+			fmt.Fprintf(&out, "- %s\n", waiting)
 		}
 	}
 
 	if len(r.gone) > 0 {
-		out += "Gone Phases:\n"
+		fmt.Fprintln(&out, "Gone Phases:")
+
 		for _, gone := range r.gone {
-			out += "- " + gone + "\n"
+			fmt.Fprintf(&out, "- %s\n", gone)
 		}
 	}
 
 	phasesWithResults := map[string]struct{}{}
-	out += "Phases:\n"
+
+	fmt.Fprintln(&out, "Phases:")
 
 	for _, ores := range r.phases {
 		phasesWithResults[ores.GetName()] = struct{}{}
-		out += "- " + strings.TrimSpace(strings.ReplaceAll(ores.String(), "\n", "\n  ")) + "\n"
+		fmt.Fprintf(&out, "- %s\n", strings.TrimSpace(strings.ReplaceAll(ores.String(), "\n", "\n  ")))
 	}
 
-	return out
+	return out.String()
 }
 
 // Teardown ensures the given revision is safely removed from the cluster.

--- a/machinery/revision_test.go
+++ b/machinery/revision_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"pkg.package-operator.run/boxcutter/internal/testutil"
@@ -197,4 +198,235 @@ Phases:
     Action: "Created"
 - Phase "phase-2" (Pending)
 `, r.String())
+}
+
+func TestRevisionTeardownResult_String_Complete(t *testing.T) {
+	t.Parallel()
+
+	r := revisionTeardownResult{
+		phases: []PhaseTeardownResult{
+			&phaseTeardownResult{
+				name: "phase-1",
+				gone: []types.ObjectRef{
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "",
+							Version: "v1",
+							Kind:    "ConfigMap",
+						},
+						ObjectKey: client.ObjectKey{
+							Name:      "test-cm",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			&phaseTeardownResult{
+				name: "phase-2",
+				gone: []types.ObjectRef{
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Secret",
+						},
+						ObjectKey: client.ObjectKey{
+							Name:      "test-secret",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+		},
+		active: "",
+		gone:   []string{"phase-1", "phase-2"},
+	}
+
+	expected := `Revision Teardown
+Gone Phases:
+- phase-1
+- phase-2
+Phases:
+- Phase "phase-1"
+  Gone Objects:
+  - /v1, Kind=ConfigMap default/test-cm
+- Phase "phase-2"
+  Gone Objects:
+  - /v1, Kind=Secret default/test-secret
+`
+
+	assert.Equal(t, expected, r.String())
+}
+
+func TestRevisionTeardownResult_String_WithActiveAndWaiting(t *testing.T) {
+	t.Parallel()
+
+	r := revisionTeardownResult{
+		phases: []PhaseTeardownResult{
+			&phaseTeardownResult{
+				name: "phase-3",
+				gone: []types.ObjectRef{
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Service",
+						},
+						ObjectKey: client.ObjectKey{
+							Name:      "my-service",
+							Namespace: "test-ns",
+						},
+					},
+				},
+			},
+			&phaseTeardownResult{
+				name: "phase-2",
+				waiting: []types.ObjectRef{
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "apps",
+							Version: "v1",
+							Kind:    "Deployment",
+						},
+						ObjectKey: client.ObjectKey{
+							Name:      "my-deployment",
+							Namespace: "test-ns",
+						},
+					},
+				},
+			},
+		},
+		active:  "phase-2",
+		waiting: []string{"phase-1"},
+		gone:    []string{"phase-3"},
+	}
+
+	expected := `Revision Teardown
+Active: phase-2
+Waiting Phases:
+- phase-1
+Gone Phases:
+- phase-3
+Phases:
+- Phase "phase-3"
+  Gone Objects:
+  - /v1, Kind=Service test-ns/my-service
+- Phase "phase-2"
+  Waiting Objects:
+  - apps/v1, Kind=Deployment test-ns/my-deployment
+`
+
+	assert.Equal(t, expected, r.String())
+}
+
+func TestRevisionTeardownResult_String_Empty(t *testing.T) {
+	t.Parallel()
+
+	r := revisionTeardownResult{
+		phases: []PhaseTeardownResult{},
+	}
+
+	expected := `Revision Teardown
+Phases:
+`
+
+	assert.Equal(t, expected, r.String())
+}
+
+func TestRevisionTeardownResult_String_OnlyActive(t *testing.T) {
+	t.Parallel()
+
+	r := revisionTeardownResult{
+		phases: []PhaseTeardownResult{
+			&phaseTeardownResult{
+				name: "phase-1",
+				waiting: []types.ObjectRef{
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Pod",
+						},
+						ObjectKey: client.ObjectKey{
+							Name:      "my-pod",
+							Namespace: "kube-system",
+						},
+					},
+				},
+			},
+		},
+		active: "phase-1",
+	}
+
+	expected := `Revision Teardown
+Active: phase-1
+Phases:
+- Phase "phase-1"
+  Waiting Objects:
+  - /v1, Kind=Pod kube-system/my-pod
+`
+
+	assert.Equal(t, expected, r.String())
+}
+
+func TestRevisionTeardownResult_String_MultipleWaitingAndGone(t *testing.T) {
+	t.Parallel()
+
+	r := revisionTeardownResult{
+		phases: []PhaseTeardownResult{
+			&phaseTeardownResult{
+				name: "phase-4",
+				gone: []types.ObjectRef{
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "rbac.authorization.k8s.io",
+							Version: "v1",
+							Kind:    "Role",
+						},
+						ObjectKey: client.ObjectKey{
+							Name:      "admin-role",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			&phaseTeardownResult{
+				name: "phase-3",
+				gone: []types.ObjectRef{
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "",
+							Version: "v1",
+							Kind:    "ServiceAccount",
+						},
+						ObjectKey: client.ObjectKey{
+							Name:      "my-sa",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+		},
+		active:  "phase-2",
+		waiting: []string{"phase-1"},
+		gone:    []string{"phase-3", "phase-4"},
+	}
+
+	expected := `Revision Teardown
+Active: phase-2
+Waiting Phases:
+- phase-1
+Gone Phases:
+- phase-3
+- phase-4
+Phases:
+- Phase "phase-4"
+  Gone Objects:
+  - rbac.authorization.k8s.io/v1, Kind=Role default/admin-role
+- Phase "phase-3"
+  Gone Objects:
+  - /v1, Kind=ServiceAccount default/my-sa
+`
+
+	assert.Equal(t, expected, r.String())
 }

--- a/machinery/types/options.go
+++ b/machinery/types/options.go
@@ -225,6 +225,7 @@ func WithProbe(t string, probe Prober) ObjectReconcileOption {
 			if opts.Probes == nil {
 				opts.Probes = map[string]Prober{}
 			}
+
 			opts.Probes[t] = probe
 		},
 	}

--- a/managedcache/objectboundaccess.go
+++ b/managedcache/objectboundaccess.go
@@ -338,6 +338,7 @@ func (m *objectBoundAccessManagerImpl[T]) handleAccessorRequest(
 
 	go func(ctx context.Context, doneCh chan<- cacheDone) {
 		defer wg.Done()
+
 		doneCh <- cacheDone{key: key, err: ctrlcache.Start(ctx)}
 	}(ctx, doneCh)
 
@@ -364,6 +365,7 @@ func (m *objectBoundAccessManagerImpl[T]) request(
 	}
 
 	responseCh := make(chan accessorResponse, 1)
+
 	req.responseCh = responseCh
 	select {
 	case accCh <- req:

--- a/test/comparator_test.go
+++ b/test/comparator_test.go
@@ -47,7 +47,6 @@ func TestComparator(t *testing.T) {
 	}
 	require.NoError(t, Client.Create(t.Context(), owner, client.FieldOwner(fieldOwner)))
 	t.Cleanup(func() {
-		//nolint:usetesting
 		if err := Client.Delete(context.Background(), owner); err != nil {
 			t.Error(err)
 		}

--- a/test/objects_test.go
+++ b/test/objects_test.go
@@ -38,7 +38,6 @@ func TestObjectEngine(t *testing.T) {
 	}
 	require.NoError(t, Client.Create(ctx, owner, client.FieldOwner(fieldOwner)))
 	t.Cleanup(func() {
-		//nolint:usetesting
 		if err := Client.Delete(context.Background(), owner); err != nil {
 			t.Error(err)
 		}
@@ -164,7 +163,6 @@ func TestObjectEnginePaused(t *testing.T) {
 	}
 	require.NoError(t, Client.Create(ctx, owner, client.FieldOwner(fieldOwner)))
 	t.Cleanup(func() {
-		//nolint:usetesting
 		if err := Client.Delete(context.Background(), owner); err != nil {
 			t.Error(err)
 		}
@@ -285,7 +283,6 @@ func TestObjectEngineProbing(t *testing.T) {
 	}
 	require.NoError(t, Client.Create(ctx, owner, client.FieldOwner(fieldOwner)))
 	t.Cleanup(func() {
-		//nolint:usetesting
 		if err := Client.Delete(context.Background(), owner); err != nil {
 			t.Error(err)
 		}

--- a/test/revision_engine_basic_test.go
+++ b/test/revision_engine_basic_test.go
@@ -84,7 +84,6 @@ func TestRevisionEngine(t *testing.T) {
 	err := Client.Create(ctx, revOwner)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		//nolint:usetesting
 		require.NoError(t, Client.Delete(context.Background(), revOwner))
 	})
 

--- a/test/test_util.go
+++ b/test/test_util.go
@@ -29,7 +29,6 @@ func cleanupOnSuccess(t *testing.T, obj client.Object) {
 	t.Cleanup(func() {
 		if !t.Failed() {
 			// Make sure objects are completely gone before closing the test.
-			//nolint:usetesting
 			ctx := context.Background()
 			_ = Client.Delete(ctx, obj, client.PropagationPolicy(metav1.DeletePropagationForeground))
 			_ = Waiter.WaitToBeGone(ctx, obj, func(client.Object) (bool, error) { return false, nil })

--- a/validation/phase.go
+++ b/validation/phase.go
@@ -146,7 +146,7 @@ func checkForObjectDuplicates(phases ...types.Phase) []ObjectValidationError {
 	ovs := make([]ObjectValidationError, 0, len(conflicts))
 
 	for objRef, phasesMap := range conflicts {
-		var phases []string
+		phases := make([]string, 0, len(phasesMap))
 		for p := range phasesMap {
 			phases = append(phases, p)
 		}

--- a/validation/revision.go
+++ b/validation/revision.go
@@ -34,7 +34,6 @@ func (v *RevisionValidator) Validate(_ context.Context, rev types.Revision) erro
 func staticValidateMultiplePhases(phases ...types.Phase) []PhaseValidationError {
 	dups := checkForObjectDuplicates(phases...)
 
-	//nolint:prealloc
 	var phaseErrors []PhaseValidationError
 
 	for _, phase := range phases {


### PR DESCRIPTION
### Summary
Golang ci lint did no longer run against the current golang version, requiring an update.

### Change Type

Bug Fix

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
