### PR TITLE
Add WithAggregatePhase...Errors to continue phase handling on error (#491)

### DIFF
--- a/boxcutter.go
+++ b/boxcutter.go
@@ -82,6 +82,14 @@ type WithCollisionProtection = types.WithCollisionProtection
 // Can also be described as dry-run, as no modification will occur.
 type WithPaused = types.WithPaused
 
+// WithAggregatePhaseReconcileErrors causes phase reconciliation to aggregate all object
+// errors as a single error instead of returning on the first error.
+var WithAggregatePhaseReconcileErrors = types.WithAggregatePhaseReconcileErrors
+
+// WithAggregatePhaseTeardownErrors causes phase teardown to aggregate all object
+// errors as a single error instead of returning on the first error.
+var WithAggregatePhaseTeardownErrors = types.WithAggregatePhaseTeardownErrors
+
 // Prober needs to be implemented by any probing implementation.
 type Prober = types.Prober
 

--- a/machinery/phases.go
+++ b/machinery/phases.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"pkg.package-operator.run/boxcutter/machinery/types"
@@ -145,11 +146,24 @@ func (e *PhaseEngine) Teardown(
 
 	res := &phaseTeardownResult{name: phase.GetName()}
 
-	for _, obj := range phase.GetObjects() {
+	objects := phase.GetObjects()
+	errs := make([]error, 0, len(objects))
+
+	for _, obj := range objects {
 		gone, err := e.objectEngine.Teardown(
 			ctx, revision, obj, options.ForObject(obj)...)
 		if err != nil {
-			return res, fmt.Errorf("teardown object: %w", err)
+			err = fmt.Errorf("teardown %s: %w", types.ToObjectRef(obj), err)
+			if options.AggregateErrors {
+				errs = append(errs, err)
+				if apierrors.IsTooManyRequests(err) {
+					return res, errors.Join(errs...)
+				}
+
+				continue
+			} else {
+				return res, err
+			}
 		}
 
 		if gone {
@@ -159,7 +173,7 @@ func (e *PhaseEngine) Teardown(
 		}
 	}
 
-	return res, nil
+	return res, errors.Join(errs...)
 }
 
 // Reconcile runs actions to bring actual state closer to desired.
@@ -194,17 +208,30 @@ func (e *PhaseEngine) Reconcile(
 	}
 
 	// Reconcile
-	for _, obj := range phase.GetObjects() {
+	objects := phase.GetObjects()
+	errs := make([]error, 0, len(objects))
+
+	for _, obj := range objects {
 		ores, err := e.objectEngine.Reconcile(
 			ctx, revision, obj, options.ForObject(obj)...)
 		if err != nil {
-			return pres, fmt.Errorf("reconciling object: %w", err)
+			err = fmt.Errorf("reconciling %s: %w", types.ToObjectRef(obj), err)
+			if options.AggregateErrors {
+				errs = append(errs, err)
+				if apierrors.IsTooManyRequests(err) {
+					return pres, errors.Join(errs...)
+				}
+
+				continue
+			} else {
+				return pres, err
+			}
 		}
 
 		pres.objects = append(pres.objects, ores)
 	}
 
-	return pres, nil
+	return pres, errors.Join(errs...)
 }
 
 // PhaseResult interface to access results of phase reconcile.

--- a/machinery/phases_test.go
+++ b/machinery/phases_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -150,6 +151,164 @@ func TestPhaseEngine_Teardown(t *testing.T) {
 	assert.True(t, deleted.IsComplete())
 	assert.Empty(t, deleted.Waiting())
 	assert.Len(t, deleted.Gone(), 2)
+}
+
+func TestPhaseEngine_AggregateErrors(t *testing.T) {
+	t.Parallel()
+
+	obj1 := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"name":      "secret1",
+				"namespace": "test",
+			},
+		},
+	}
+	obj2 := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]any{
+				"name":      "cm1",
+				"namespace": "test",
+			},
+		},
+	}
+
+	t.Run("Reconcile", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name             string
+			obj1Error        error
+			obj2Error        error
+			expectedCalls    int
+			checkTooManyReqs bool
+			checkObjRefs     bool
+		}{
+			{
+				name:          "aggregates multiple errors",
+				obj1Error:     errTest,
+				obj2Error:     errTest,
+				expectedCalls: 2,
+				checkObjRefs:  true,
+			},
+			{
+				name:             "short-circuits on TooManyRequests",
+				obj1Error:        apierrors.NewTooManyRequests("slow down", 5),
+				obj2Error:        errTest,
+				expectedCalls:    1,
+				checkTooManyReqs: true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				oe := &objectEngineMock{}
+				pv := &phaseValidatorMock{}
+				pe := NewPhaseEngine(oe, pv)
+
+				var revision int64 = 1
+
+				pv.
+					On("Validate", mock.Anything, mock.Anything, mock.Anything).
+					Return(nil)
+				oe.On("Reconcile", mock.Anything, revision, obj1, mock.Anything).
+					Return(ObjectResultCreated{}, tt.obj1Error)
+				oe.On("Reconcile", mock.Anything, revision, obj2, mock.Anything).
+					Return(ObjectResultCreated{}, tt.obj2Error)
+
+				_, err := pe.Reconcile(t.Context(), revision, types.NewPhase(
+					"test",
+					[]client.Object{obj1, obj2},
+				), types.WithAggregatePhaseReconcileErrors())
+
+				require.Error(t, err)
+
+				if tt.checkTooManyReqs {
+					assert.True(t, apierrors.IsTooManyRequests(err))
+				} else {
+					require.ErrorIs(t, err, errTest)
+
+					if tt.checkObjRefs {
+						assert.Contains(t, err.Error(), types.ToObjectRef(obj1).String())
+						assert.Contains(t, err.Error(), types.ToObjectRef(obj2).String())
+					}
+				}
+
+				oe.AssertNumberOfCalls(t, "Reconcile", tt.expectedCalls)
+			})
+		}
+	})
+
+	t.Run("Teardown", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name             string
+			obj1Error        error
+			obj2Error        error
+			expectedCalls    int
+			checkTooManyReqs bool
+			checkObjRefs     bool
+		}{
+			{
+				name:          "aggregates multiple errors",
+				obj1Error:     errTest,
+				obj2Error:     errTest,
+				expectedCalls: 2,
+				checkObjRefs:  true,
+			},
+			{
+				name:             "short-circuits on TooManyRequests",
+				obj1Error:        apierrors.NewTooManyRequests("slow down", 5),
+				obj2Error:        errTest,
+				expectedCalls:    1,
+				checkTooManyReqs: true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				oe := &objectEngineMock{}
+				pv := &phaseValidatorMock{}
+				pe := NewPhaseEngine(oe, pv)
+
+				var revision int64 = 1
+
+				oe.On("Teardown", mock.Anything, revision, obj1, mock.Anything).
+					Return(false, tt.obj1Error)
+				oe.On("Teardown", mock.Anything, revision, obj2, mock.Anything).
+					Return(false, tt.obj2Error)
+
+				_, err := pe.Teardown(t.Context(), revision, types.NewPhase(
+					"test",
+					[]client.Object{obj1, obj2},
+				), types.WithAggregatePhaseTeardownErrors())
+
+				require.Error(t, err)
+
+				if tt.checkTooManyReqs {
+					assert.True(t, apierrors.IsTooManyRequests(err))
+				} else {
+					require.ErrorIs(t, err, errTest)
+
+					if tt.checkObjRefs {
+						assert.Contains(t, err.Error(), types.ToObjectRef(obj1).String())
+						assert.Contains(t, err.Error(), types.ToObjectRef(obj2).String())
+					}
+				}
+
+				oe.AssertNumberOfCalls(t, "Teardown", tt.expectedCalls)
+			})
+		}
+	})
 }
 
 type objectEngineMock struct {

--- a/machinery/types/options.go
+++ b/machinery/types/options.go
@@ -69,6 +69,8 @@ type PhaseReconcileOptions struct {
 	DefaultObjectOptions []ObjectReconcileOption
 	// ObjectOptions maps ObjectOptions for specific objects.
 	ObjectOptions map[ObjectRef][]ObjectReconcileOption
+	// AggregateErrors aggregates all object errors from the phase and returns them as a single error.
+	AggregateErrors bool
 }
 
 // ForObject returns the options for the given object.
@@ -94,6 +96,8 @@ type PhaseTeardownOptions struct {
 	DefaultObjectOptions []ObjectTeardownOption
 	// ObjectOptions maps ObjectOptions for specific objects.
 	ObjectOptions map[ObjectRef][]ObjectTeardownOption
+	// AggregateErrors aggregates all object errors from the phase and returns them as a single error.
+	AggregateErrors bool
 }
 
 // ForObject returns the options for the given object.
@@ -267,6 +271,22 @@ func WithOrphan() ObjectTeardownOption {
 			opts.Orphan = true
 		},
 	}
+}
+
+// WithAggregatePhaseReconcileErrors causes phase reconciliation to aggregate all object
+// errors as a single error instead of returning on the first error.
+func WithAggregatePhaseReconcileErrors() PhaseReconcileOption {
+	return phaseReconcileOptionFn(func(opts *PhaseReconcileOptions) {
+		opts.AggregateErrors = true
+	})
+}
+
+// WithAggregatePhaseTeardownErrors causes phase teardown to aggregate all object
+// errors as a single error instead of returning on the first error.
+func WithAggregatePhaseTeardownErrors() PhaseTeardownOption {
+	return phaseTeardownOptionFn(func(opts *PhaseTeardownOptions) {
+		opts.AggregateErrors = true
+	})
 }
 
 // WithTeardownWriter tears down the revision with the given writer.
@@ -453,6 +473,30 @@ func (p *optionFn) ApplyToPhaseReconcileOptions(opts *PhaseReconcileOptions) {
 
 // ApplyToRevisionReconcileOptions implements RevisionReconcileOptions.
 func (p *optionFn) ApplyToRevisionReconcileOptions(opts *RevisionReconcileOptions) {
+	opts.DefaultPhaseOptions = append(opts.DefaultPhaseOptions, p)
+}
+
+type phaseReconcileOptionFn func(opts *PhaseReconcileOptions)
+
+// ApplyToPhaseReconcileOptions implements PhaseOption.
+func (p phaseReconcileOptionFn) ApplyToPhaseReconcileOptions(opts *PhaseReconcileOptions) {
+	p(opts)
+}
+
+// ApplyToRevisionReconcileOptions implements RevisionReconcileOptions.
+func (p phaseReconcileOptionFn) ApplyToRevisionReconcileOptions(opts *RevisionReconcileOptions) {
+	opts.DefaultPhaseOptions = append(opts.DefaultPhaseOptions, p)
+}
+
+type phaseTeardownOptionFn func(opts *PhaseTeardownOptions)
+
+// ApplyToPhaseTeardownOptions implements PhaseOption.
+func (p phaseTeardownOptionFn) ApplyToPhaseTeardownOptions(opts *PhaseTeardownOptions) {
+	p(opts)
+}
+
+// ApplyToRevisionTeardownOptions implements RevisionTeardownOptions.
+func (p phaseTeardownOptionFn) ApplyToRevisionTeardownOptions(opts *RevisionTeardownOptions) {
 	opts.DefaultPhaseOptions = append(opts.DefaultPhaseOptions, p)
 }
 

--- a/machinery/types/options_test.go
+++ b/machinery/types/options_test.go
@@ -585,6 +585,50 @@ func TestWithOrphan(t *testing.T) {
 	})
 }
 
+func TestWithAggregatePhaseReconcileErrors(t *testing.T) {
+	t.Parallel()
+
+	opt := WithAggregatePhaseReconcileErrors()
+
+	t.Run("applies to phase reconcile options", func(t *testing.T) {
+		t.Parallel()
+
+		opts := &PhaseReconcileOptions{}
+		opt.ApplyToPhaseReconcileOptions(opts)
+		assert.True(t, opts.AggregateErrors)
+	})
+
+	t.Run("applies to revision reconcile options", func(t *testing.T) {
+		t.Parallel()
+
+		opts := &RevisionReconcileOptions{}
+		opt.ApplyToRevisionReconcileOptions(opts)
+		require.Len(t, opts.DefaultPhaseOptions, 1)
+	})
+}
+
+func TestWithAggregatePhaseTeardownErrors(t *testing.T) {
+	t.Parallel()
+
+	opt := WithAggregatePhaseTeardownErrors()
+
+	t.Run("applies to phase teardown options", func(t *testing.T) {
+		t.Parallel()
+
+		opts := &PhaseTeardownOptions{}
+		opt.ApplyToPhaseTeardownOptions(opts)
+		assert.True(t, opts.AggregateErrors)
+	})
+
+	t.Run("applies to revision teardown options", func(t *testing.T) {
+		t.Parallel()
+
+		opts := &RevisionTeardownOptions{}
+		opt.ApplyToRevisionTeardownOptions(opts)
+		require.Len(t, opts.DefaultPhaseOptions, 1)
+	})
+}
+
 func TestWithTeardownWriter(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
Adds WithAggregatePhaseReconcileErrors and WithAggregatePhaseTeardownErrors.
These are Phase options, so they can be applied to either the Phase or the
Revision. If applied, the phase handler will attempt to reconcile every object
in the phase even if some return errors. It will return all errors as a single,
aggregated error.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

Related to https://github.com/package-operator/boxcutter/issues/491
