### PR TITLE
Add FieldValue Probe

### DIFF
--- a/probing/fieldvalue.go
+++ b/probing/fieldvalue.go
@@ -1,0 +1,64 @@
+package probing
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// FieldValueProbe checks if the value found at FieldPath matches the provided Value.
+type FieldValueProbe struct {
+	FieldPath, Value string
+}
+
+var _ Prober = (*FieldValueProbe)(nil)
+
+// Probe executes the probe.
+func (fv *FieldValueProbe) Probe(obj client.Object) Result {
+	return probeUnstructuredSingleMsg(obj, fv.probe)
+}
+
+func (fv *FieldValueProbe) probe(obj *unstructured.Unstructured) Result {
+	fieldPath := strings.Split(strings.Trim(fv.FieldPath, "."), ".")
+
+	fieldVal, ok, err := unstructured.NestedFieldCopy(obj.Object, fieldPath...)
+	if err != nil {
+		return Result{
+			Status:   StatusFalse,
+			Messages: []string{fmt.Sprintf(`error locating key %q; %v`, fv.FieldPath, err)},
+		}
+	}
+
+	if !ok {
+		return Result{
+			Status:   StatusFalse,
+			Messages: []string{fmt.Sprintf(`missing key: %q`, fv.FieldPath)},
+		}
+	}
+
+	if !equality.Semantic.DeepEqual(fieldVal, fv.Value) {
+		foundJSON, err := json.Marshal(fieldVal)
+		if err != nil {
+			foundJSON = []byte("<value marshal failed>")
+		}
+
+		expectedJSON, err := json.Marshal(fv.Value)
+		if err != nil {
+			expectedJSON = []byte("<value marshal failed>")
+		}
+
+		return Result{
+			Status:   StatusFalse,
+			Messages: []string{fmt.Sprintf(`value at key %q != %q; expected: %s got: %s`, fv.FieldPath, fv.Value, expectedJSON, foundJSON)},
+		}
+	}
+
+	return Result{
+		Status:   StatusTrue,
+		Messages: []string{fmt.Sprintf(`value at key %q == %q`, fv.FieldPath, fv.Value)},
+	}
+}

--- a/probing/fieldvalue_test.go
+++ b/probing/fieldvalue_test.go
@@ -1,0 +1,71 @@
+package probing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func Test_FieldValueProbe(t *testing.T) {
+	t.Parallel()
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"spec": map[string]any{
+				"field": "test",
+			},
+		},
+	}
+
+	for _, tc := range []struct {
+		name           string
+		probe          FieldValueProbe
+		expectedResult Result
+	}{
+		{
+			name: "True result with found key and equal value",
+			probe: FieldValueProbe{
+				FieldPath: "spec.field",
+				Value:     "test",
+			},
+			expectedResult: Result{
+				Status: StatusTrue,
+				Messages: []string{
+					`value at key "spec.field" == "test"`,
+				},
+			},
+		},
+		{
+			name: "False result with missing key",
+			probe: FieldValueProbe{
+				FieldPath: "spec.foo",
+				Value:     "test",
+			},
+			expectedResult: Result{
+				Status: StatusFalse,
+				Messages: []string{
+					`missing key: "spec.foo"`,
+				},
+			},
+		},
+		{
+			name: "False result with found key and unequal value",
+			probe: FieldValueProbe{
+				FieldPath: "spec.field",
+				Value:     "bar",
+			},
+			expectedResult: Result{
+				Status: StatusFalse,
+				Messages: []string{
+					`value at key "spec.field" != "bar"; expected: "bar" got: "test"`,
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expectedResult, tc.probe.Probe(obj))
+		})
+	}
+}


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>]'-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

Adds an additional probe type which enables probing by checking that the value at a given FieldPath equals a given value. Enables simple probing of objects such as Namespaces which use a simple status field rather than conditions e.g. `"status.phase" == "Active"` and without requiring CEL. Closely emulates FieldsEqual probe.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->

Currently being used in [operator-controller](https://github.com/operator-framework/operator-controller/blob/253feaef5babbdabfb4b63d1cb3a60455947be3a/internal/operator-controller/applier/phase.go#L210).