### PR TITLE
bugfix: ensure collision detection runs before revision linearity check

### DIFF
--- a/machinery/objects.go
+++ b/machinery/objects.go
@@ -322,22 +322,27 @@ func (e *ObjectEngine) objectUpdateHandling(
 		return nil, err
 	}
 
-	// Ensure revision linearity.
+	// Get actual revision to ensure revision linearity
 	actualObjectRevision, err := e.getObjectRevision(actualObject)
 	if err != nil {
 		return nil, fmt.Errorf("getting revision of object: %w", err)
 	}
 
-	if actualObjectRevision > revision {
-		// Leave object alone.
-		// It's already owned by a later revision.
-		return newObjectResultProgressed(
-			actualObject, compareRes, options,
-		), nil
-	}
-
 	switch ctrlSit {
 	case ctrlSituationIsController:
+		// Ensure revision linearity.
+		// Only skip reconciliation for a newer revision when we are
+		// already the controller or a previous owner is the controller.
+		// For unknown or absent controllers, collision protection must
+		// be evaluated first.
+		if actualObjectRevision > revision {
+			// Leave object alone.
+			// It's already owned by a later revision.
+			return newObjectResultProgressed(
+				actualObject, compareRes, options,
+			), nil
+		}
+
 		modified := compareRes.Comparison != nil &&
 			(!compareRes.Comparison.Modified.Empty() ||
 				!compareRes.Comparison.Removed.Empty())
@@ -439,6 +444,13 @@ func (e *ObjectEngine) objectUpdateHandling(
 	// This means we want to take control, but
 	// retain older revisions ownerReferences,
 	// so they can still react to events.
+
+	// Ensure revision linearity
+	if actualObjectRevision > revision {
+		return newObjectResultProgressed(
+			actualObject, compareRes, options,
+		), nil
+	}
 
 	// TODO:
 	// ObjectResult ModifiedFields does not contain ownerReference changes

--- a/machinery/objects_test.go
+++ b/machinery/objects_test.go
@@ -229,7 +229,7 @@ func TestObjectEngine(t *testing.T) {
 			},
 			expectedAction: ActionCreated,
 		},
-		{ //nolint:dupl
+		{
 			name:           "Idle",
 			revision:       1,
 			desiredObject:  buildObj("testi", "test"),
@@ -326,12 +326,13 @@ func TestObjectEngine(t *testing.T) {
 			},
 			expectedAction: ActionRecovered,
 		},
-		{ //nolint:dupl
+		{
 			name:           "Progressed",
 			revision:       1,
 			desiredObject:  buildObj("testi", "test"),
 			actualObject:   buildObj("testi", "test", withRevision("4"), withManaged),
 			expectedObject: buildObj("testi", "test", withRevision("4"), withManaged),
+			modes:          []ownerMode{withNativeOwnerMode},
 			mockSetup: func(
 				cache *cacheMock, writer *testutil.CtrlClient,
 				ddm *comparatorMock, actualObject *unstructured.Unstructured,
@@ -353,6 +354,95 @@ func TestObjectEngine(t *testing.T) {
 					Return(nil)
 			},
 			expectedAction: ActionProgressed,
+		},
+		{
+			name:          "Progressed - previousOwner higher revision",
+			revision:      1,
+			desiredObject: buildObj("testi", "test"),
+			actualObject: buildObj("testi", "test", withRevision("4"),
+				withOwnerRef("v1", "ConfigMap", "old-owner", "6789", true)),
+			expectedObject: buildObj("testi", "test", withRevision("4"),
+				withOwnerRef("v1", "ConfigMap", "old-owner", "6789", true)),
+			modes: []ownerMode{withNativeOwnerMode},
+			opts: []types.ObjectReconcileOption{
+				types.WithPreviousOwners{&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "6789", Name: "old-owner", Namespace: "test",
+					},
+				}},
+			},
+			mockSetup: func(
+				cache *cacheMock, writer *testutil.CtrlClient,
+				ddm *comparatorMock, actualObject *unstructured.Unstructured,
+			) {
+				cache.
+					On("Get", mock.Anything,
+						client.ObjectKeyFromObject(actualObject),
+						mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) {
+						obj := args.Get(2).(*unstructured.Unstructured)
+						*obj = *actualObject
+					}).
+					Return(nil)
+				ddm.
+					On("Compare", mock.Anything, mock.Anything, mock.Anything).
+					Return(CompareResult{}, nil)
+			},
+			expectedAction: ActionProgressed,
+		},
+		{
+			name:          "Collision - unknown controller higher revision",
+			revision:      1,
+			desiredObject: buildObj("testi", "test"),
+			actualObject: buildObj("testi", "test", withRevision("4"),
+				withOwnerRef("v1", "Node", "node1", "xxxx", true)),
+			expectedObject: buildObj("testi", "test", withRevision("4"),
+				withOwnerRef("v1", "Node", "node1", "xxxx", true)),
+			modes: []ownerMode{withNativeOwnerMode},
+			mockSetup: func(
+				cache *cacheMock, writer *testutil.CtrlClient,
+				ddm *comparatorMock, actualObject *unstructured.Unstructured,
+			) {
+				cache.
+					On("Get", mock.Anything,
+						client.ObjectKeyFromObject(actualObject),
+						mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) {
+						obj := args.Get(2).(*unstructured.Unstructured)
+						*obj = *actualObject
+					}).
+					Return(nil)
+				ddm.
+					On("Compare", mock.Anything, mock.Anything, mock.Anything).
+					Return(CompareResult{}, nil)
+			},
+			expectedAction: ActionCollision,
+		},
+		{
+			name:           "Collision - no controller higher revision boxcutter managed",
+			revision:       1,
+			desiredObject:  buildObj("testi", "test"),
+			actualObject:   buildObj("testi", "test", withRevision("4"), withBoxcutterManagedLabel),
+			expectedObject: buildObj("testi", "test", withRevision("4"), withBoxcutterManagedLabel),
+			modes:          []ownerMode{withNativeOwnerMode},
+			mockSetup: func(
+				cache *cacheMock, _ *testutil.CtrlClient,
+				ddm *comparatorMock, actualObject *unstructured.Unstructured,
+			) {
+				cache.
+					On("Get", mock.Anything,
+						client.ObjectKeyFromObject(actualObject),
+						mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) {
+						obj := args.Get(2).(*unstructured.Unstructured)
+						*obj = *actualObject
+					}).
+					Return(nil)
+				ddm.
+					On("Compare", mock.Anything, mock.Anything, mock.Anything).
+					Return(CompareResult{}, nil)
+			},
+			expectedAction: ActionCollision,
 		},
 		{
 			name:           "Updated noController CollisionProtectionIfNoController",


### PR DESCRIPTION
## Summary

- Fixes a bug where a resource owned by a different parent object at a higher revision was reported as `ActionProgressed` instead of `ActionCollision`
- Moves the revision linearity check from a top-level early return into the `ctrlSituationIsController` and `ctrlSituationPreviousIsController` switch cases, ensuring `ctrlSituationUnknownController` and `ctrlSituationNoController` always evaluate collision protection regardless of revision
- Adds test coverage for cross-owner collision scenarios with higher revisions

## Details

The revision linearity check in `objectUpdateHandling()` (`actualObjectRevision > revision`) was evaluated before the ownership-based collision protection switch statement. This meant that if Revision 2 (Parent-B) created a CRD and Revision 1 (Parent-A) later reconciled the same CRD, the check would short-circuit and return `ActionProgressed` before collision detection could run.

The fix restricts the linearity check to the two cases where it is safe to skip reconciliation:
- `ctrlSituationIsController`: we already own the object
- `ctrlSituationPreviousIsController`: a known previous owner has it

## Test plan

- [x] Existing "Progressed" test scoped to `withNativeOwnerMode` only
- [x] Added "Progressed - previousOwner higher revision" test — verifies `ActionProgressed` for known lineage
- [x] Added "Collision - unknown controller higher revision" test — verifies `ActionCollision` for cross-owner conflict
- [x] Added "Collision - no controller higher revision boxcutter managed" test — verifies `ActionCollision` for orphaned boxcutter-managed objects
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)