### PR TITLE
PKO-409: Make app.kubernetes.io/managed-by label customiseable

### DIFF
--- a/boxcutter.go
+++ b/boxcutter.go
@@ -137,6 +137,9 @@ type RevisionEngineOptions struct {
 
 	// Optional
 
+	// ManagedBy is the value to use for the app.kubernetes.io/managed-by label.
+	// If unset, defaults to "boxcutter".
+	ManagedBy string
 	// UnfilteredReader is a client.Reader which is not subject to filtering
 	// which may be applied to Reader if it is cached using object selectors.
 	// UnfilteredReader is used rarely in edge cases that do not persist, so it
@@ -163,7 +166,7 @@ func NewPhaseEngine(opts RevisionEngineOptions) (*machinery.PhaseEngine, error) 
 	oe := machinery.NewObjectEngine(
 		opts.Scheme, opts.Reader, opts.Writer,
 		comp, opts.FieldOwner, opts.SystemPrefix,
-		opts.UnfilteredReader,
+		opts.ManagedBy, opts.UnfilteredReader,
 	)
 
 	return machinery.NewPhaseEngine(oe, opts.PhaseValidator), nil
@@ -184,7 +187,7 @@ func NewRevisionEngine(opts RevisionEngineOptions) (*RevisionEngine, error) {
 	oe := machinery.NewObjectEngine(
 		opts.Scheme, opts.Reader, opts.Writer,
 		comp, opts.FieldOwner, opts.SystemPrefix,
-		opts.UnfilteredReader,
+		opts.ManagedBy, opts.UnfilteredReader,
 	)
 	pe := machinery.NewPhaseEngine(oe, pval)
 

--- a/machinery/objects.go
+++ b/machinery/objects.go
@@ -29,6 +29,7 @@ type ObjectEngine struct {
 
 	fieldOwner   string
 	systemPrefix string
+	managedBy    string
 
 	// unfilteredReader is a client.Reader which is not subject to filtering
 	// which may have been applied to cache. unfilteredReader MUST ONLY be used
@@ -48,9 +49,14 @@ func NewObjectEngine(
 
 	fieldOwner string,
 	systemPrefix string,
+	managedBy string,
 
 	unfilteredReader client.Reader, // may be nil
 ) *ObjectEngine {
+	if managedBy == "" {
+		managedBy = managedByLabelDefaultValue
+	}
+
 	return &ObjectEngine{
 		scheme:           scheme,
 		cache:            cache,
@@ -60,6 +66,7 @@ func NewObjectEngine(
 
 		fieldOwner:   fieldOwner,
 		systemPrefix: systemPrefix,
+		managedBy:    managedBy,
 	}
 }
 
@@ -86,9 +93,9 @@ type comparator interface {
 }
 
 const (
-	managedByLabel        string = "app.kubernetes.io/managed-by"
-	managedByLabelValue   string = "boxcutter"
-	boxcutterManagedLabel string = "boxcutter-managed"
+	managedByLabel             string = "app.kubernetes.io/managed-by"
+	managedByLabelDefaultValue string = "boxcutter"
+	boxcutterManagedLabel      string = "boxcutter-managed"
 )
 
 // Teardown ensures the given object is safely removed from the cluster.
@@ -205,7 +212,7 @@ func (e *ObjectEngine) Reconcile(
 		labels = map[string]string{}
 	}
 
-	labels[managedByLabel] = managedByLabelValue
+	labels[managedByLabel] = e.managedBy
 	desiredObject.SetLabels(labels)
 
 	options.Default()
@@ -522,15 +529,10 @@ func (e *ObjectEngine) objectUpdateHandling(
 // It's only purpose is to prevent boxcutter immediately re-adopting objects when
 // resources get orphaned by the GC.
 func (e *ObjectEngine) isBoxcutterManaged(obj client.Object) bool {
-	labels := obj.GetLabels()
 	annotations := obj.GetAnnotations()
-
 	_, hasRevisionAnnotation := annotations[e.revisionAnnotation()]
-	if labels[managedByLabel] == managedByLabelValue && hasRevisionAnnotation {
-		return true
-	}
 
-	return false
+	return hasRevisionAnnotation
 }
 
 func (e *ObjectEngine) create(
@@ -696,10 +698,7 @@ func (e *ObjectEngine) removeBoxcutterManagedLabelsAndAnnotations(
 	obj.SetAnnotations(annotations)
 
 	labels := updated.GetLabels()
-	if l, ok := labels[managedByLabel]; ok && l == managedByLabelValue {
-		delete(labels, managedByLabel)
-	}
-
+	delete(labels, managedByLabel)
 	delete(labels, boxcutterManagedLabel)
 
 	updated.SetLabels(labels)

--- a/machinery/objects_test.go
+++ b/machinery/objects_test.go
@@ -124,7 +124,7 @@ func setBoxcutterManagedLabel(obj *unstructured.Unstructured) {
 		labels = map[string]string{}
 	}
 
-	labels[managedByLabel] = managedByLabelValue
+	labels[managedByLabel] = managedByLabelDefaultValue
 	obj.SetLabels(labels)
 }
 
@@ -444,7 +444,7 @@ func TestObjectEngine(t *testing.T) {
 			},
 			expectedAction: ActionCollision,
 		},
-		{
+		{ //nolint:dupl // Similar to CollisionProtectionNone test
 			name:           "Updated noController CollisionProtectionIfNoController",
 			revision:       1,
 			desiredObject:  buildObj("testi", "test"),
@@ -672,11 +672,11 @@ func TestObjectEngine(t *testing.T) {
 			},
 			expectedAction: ActionCollision,
 		},
-		{
+		{ //nolint:dupl // Similar to CollisionProtectionIfNoController test
 			name:           "Updated, CollisionProtectionNone",
 			revision:       1,
 			desiredObject:  buildObj("testi", "test"),
-			actualObject:   buildObj("testi", "test", withRevision("1")),
+			actualObject:   buildObj("testi", "test"),
 			expectedObject: buildObj("testi", "test", withRevision("1"), withManaged),
 			opts: []types.ObjectReconcileOption{
 				types.WithCollisionProtection(types.CollisionProtectionNone),
@@ -868,6 +868,7 @@ func TestObjectEngine(t *testing.T) {
 					divergeDetector,
 					testFieldOwner,
 					testSystemPrefix,
+					"",
 					nil,
 				)
 
@@ -954,6 +955,7 @@ func TestObjectEngine_Reconcile_UnsupportedTypedObject(t *testing.T) {
 			divergeDetector,
 			testFieldOwner,
 			testSystemPrefix,
+			"",
 			nil,
 		)
 
@@ -1370,6 +1372,7 @@ func TestObjectEngine_Teardown(t *testing.T) {
 					divergeDetector,
 					testFieldOwner,
 					testSystemPrefix,
+					"",
 					nil,
 				)
 
@@ -1426,7 +1429,7 @@ func TestObjectEngine_Teardown_SanityChecks(t *testing.T) {
 	})
 }
 
-func TestObjectEngine_IsBoxcutterManaged_FalseCase(t *testing.T) {
+func TestObjectEngine_IsBoxcutterManaged(t *testing.T) {
 	t.Parallel()
 
 	engine := NewObjectEngine(
@@ -1436,20 +1439,25 @@ func TestObjectEngine_IsBoxcutterManaged_FalseCase(t *testing.T) {
 		&comparatorMock{},
 		"test-owner",
 		"test-prefix",
+		"",
 		nil,
 	)
 
 	tests := []struct {
-		name   string
-		labels map[string]string
+		name        string
+		labels      map[string]string
+		annotations map[string]string
+		expected    bool
 	}{
 		{
-			name:   "no labels",
-			labels: nil,
+			name:     "no labels or annotations",
+			labels:   nil,
+			expected: false,
 		},
 		{
-			name:   "empty labels",
-			labels: map[string]string{},
+			name:     "empty labels",
+			labels:   map[string]string{},
+			expected: false,
 		},
 		{
 			name: "other labels only",
@@ -1457,12 +1465,42 @@ func TestObjectEngine_IsBoxcutterManaged_FalseCase(t *testing.T) {
 				"app": "myapp",
 				"env": "prod",
 			},
+			expected: false,
 		},
 		{
 			name: "contains but doesn't start with prefix",
 			labels: map[string]string{
 				"my-test-prefix-managed": "true",
 			},
+			expected: false,
+		},
+		{
+			name:   "revision annotation only, no labels",
+			labels: nil,
+			annotations: map[string]string{
+				"test-prefix/revision": "1",
+			},
+			expected: true,
+		},
+		{
+			name: "revision annotation with managed-by label",
+			labels: map[string]string{
+				managedByLabel: managedByLabelDefaultValue,
+			},
+			annotations: map[string]string{
+				"test-prefix/revision": "1",
+			},
+			expected: true,
+		},
+		{
+			name: "revision annotation with unrelated labels",
+			labels: map[string]string{
+				"app": "myapp",
+			},
+			annotations: map[string]string{
+				"test-prefix/revision": "3",
+			},
+			expected: true,
 		},
 	}
 
@@ -1472,10 +1510,58 @@ func TestObjectEngine_IsBoxcutterManaged_FalseCase(t *testing.T) {
 
 			obj := &unstructured.Unstructured{}
 			obj.SetLabels(tt.labels)
+			obj.SetAnnotations(tt.annotations)
 
-			assert.False(t, engine.isBoxcutterManaged(obj))
+			assert.Equal(t, tt.expected, engine.isBoxcutterManaged(obj))
 		})
 	}
+}
+
+func TestObjectEngine_CustomManagedByLabel(t *testing.T) {
+	t.Parallel()
+
+	cache := &cacheMock{}
+	writer := testutil.NewClient()
+	divergeDetector := &comparatorMock{}
+
+	engine := NewObjectEngine(
+		scheme.Scheme,
+		cache, writer,
+		divergeDetector,
+		testFieldOwner,
+		testSystemPrefix,
+		"my-custom-operator",
+		nil,
+	)
+
+	desiredObject := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":      "test-custom-managed-by",
+				"namespace": "test",
+			},
+		},
+	}
+
+	cache.
+		On("Get", mock.Anything,
+			client.ObjectKey{Name: "test-custom-managed-by", Namespace: "test"},
+			mock.Anything, mock.Anything).
+		Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+	divergeDetector.
+		On("Compare", mock.Anything, mock.Anything, mock.Anything).
+		Return(CompareResult{}, nil)
+	writer.
+		On("Create", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil)
+
+	_, err := engine.Reconcile(t.Context(), 1, desiredObject)
+	require.NoError(t, err)
+
+	// Verify the managed-by label was set to our custom value.
+	assert.Equal(t, "my-custom-operator", desiredObject.GetLabels()[managedByLabel])
 }
 
 func TestObjectEngine_GetObjectRevision_Error(t *testing.T) {
@@ -1488,6 +1574,7 @@ func TestObjectEngine_GetObjectRevision_Error(t *testing.T) {
 		&comparatorMock{},
 		testFieldOwner,
 		testSystemPrefix,
+		"",
 		nil,
 	)
 
@@ -1520,6 +1607,7 @@ func TestObjectEngine_MigrateFieldManagersToSSA_NoPatch(t *testing.T) {
 		&comparatorMock{},
 		testFieldOwner,
 		testSystemPrefix,
+		"",
 		nil,
 	)
 

--- a/test/objects_test.go
+++ b/test/objects_test.go
@@ -23,7 +23,7 @@ func TestObjectEngine(t *testing.T) {
 	os := ownerhandling.NewNative(Scheme)
 	comp := machinery.NewComparator(DiscoveryClient, Scheme, fieldOwner)
 	oe := machinery.NewObjectEngine(
-		Scheme, Client, Client, comp, fieldOwner, systemPrefix, nil,
+		Scheme, Client, Client, comp, fieldOwner, systemPrefix, "", nil,
 	)
 
 	ctx := t.Context()
@@ -148,7 +148,7 @@ func TestObjectEnginePaused(t *testing.T) {
 	os := ownerhandling.NewNative(Scheme)
 	comp := machinery.NewComparator(DiscoveryClient, Scheme, fieldOwner)
 	oe := machinery.NewObjectEngine(
-		Scheme, Client, Client, comp, fieldOwner, systemPrefix, nil,
+		Scheme, Client, Client, comp, fieldOwner, systemPrefix, "", nil,
 	)
 
 	ctx := t.Context()
@@ -268,7 +268,7 @@ func TestObjectEngineProbing(t *testing.T) {
 	os := ownerhandling.NewNative(Scheme)
 	comp := machinery.NewComparator(DiscoveryClient, Scheme, fieldOwner)
 	oe := machinery.NewObjectEngine(
-		Scheme, Client, Client, comp, fieldOwner, systemPrefix, nil,
+		Scheme, Client, Client, comp, fieldOwner, systemPrefix, "", nil,
 	)
 
 	ctx := t.Context()
@@ -383,7 +383,7 @@ Probes:
 func TestObjectEngine_StaleManagedFieldMigration(t *testing.T) {
 	comp := machinery.NewComparator(DiscoveryClient, Scheme, fieldOwner)
 	oe := machinery.NewObjectEngine(
-		Scheme, Client, Client, comp, fieldOwner, systemPrefix, nil,
+		Scheme, Client, Client, comp, fieldOwner, systemPrefix, "", nil,
 	)
 
 	ctx := t.Context()

--- a/test/revision_engine_basic_test.go
+++ b/test/revision_engine_basic_test.go
@@ -55,7 +55,7 @@ func TestRevisionEngine(t *testing.T) {
 
 	comp := machinery.NewComparator(DiscoveryClient, Scheme, fieldOwner)
 	oe := machinery.NewObjectEngine(
-		Scheme, Client, Client, comp, fieldOwner, systemPrefix, nil,
+		Scheme, Client, Client, comp, fieldOwner, systemPrefix, "", nil,
 	)
 	pval := validation.NewNamespacedPhaseValidator(Client.RESTMapper(), Client)
 	pe := machinery.NewPhaseEngine(oe, pval)


### PR DESCRIPTION
### Summary
Defaults to 'boxcutter', but allows a custom value to be specified in
RevisionEngineOptions. isBoxcutterManaged is simplified to look only for
a revision label which:

* uses the system prefix, therefore should not conflict
  with other users of boxcutter in the same cluster.
* is already set unconditionally on all objects.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [X] This PR passes all pre-commit hook validations.
- [X] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
