### PR TITLE
Proposal: replace previous owners concept with sibling owners

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -5,3 +5,4 @@ ignore:
   - "**/zz_generated*.go"
   - "cmd/build"
   - "test"
+  - "cmd/reference"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+## Directives
+
+Produce concise code, comment and agent output optimized for developer experience.
+Run `go fmt ./...` to format .go files, and run `./do dev:lintfix` to lint them.
+Run `go mod tidy` after any go.mod changes.
+Run single unit tests with `go test -run '^TestName$' ./modulepath/`.
+Run the full unit test suite with `./do dev:unit`.
+Run single e2e tests with `./do dev:integration <golang test filter>`.
+Run the full e2e test suite with `./do dev:integration`. The test cluster MUST be removed with `./do dev:destroy` before rerunning e2e tests.
+Ensure no trailing whitespace in edited files but keep a trailing newline..
+Preserve existing code comments, do not remove or rewrite comments that are still relevant.
+Respect when a user tells you that a relevant repo is checked out relative to this project.
+
+## Notes
+
+This repo makes heavy use of kubernetes' server-side apply feature.
+
+Known users of this codebase are:
+- github.com/package-operator/package-operator
+- github.com/operator-framework/operator-controller
+- github.com/openshift/cluster-capi-operator

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Run single unit tests with `go test -run '^TestName$' ./modulepath/`.
 Run the full unit test suite with `./do dev:unit`.
 Run single e2e tests with `./do dev:integration <golang test filter>`.
 Run the full e2e test suite with `./do dev:integration`. The test cluster MUST be removed with `./do dev:destroy` before rerunning e2e tests.
-Ensure no trailing whitespace in edited files but keep a trailing newline..
+Ensure no trailing whitespace in edited files but keep a trailing newline.
 Preserve existing code comments, do not remove or rewrite comments that are still relevant.
 Respect when a user tells you that a relevant repo is checked out relative to this project.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/boxcutter.go
+++ b/boxcutter.go
@@ -25,6 +25,10 @@ var NewRevision = types.NewRevision
 // with the given name, rev, phases and owner.
 var NewRevisionWithOwner = types.NewRevisionWithOwner
 
+// NewRevisionWithOwnerAndSiblings creates a new RevisionBuilder
+// with the given name, rev, phases, owner and sibling owners for revision handover.
+var NewRevisionWithOwnerAndSiblings = types.NewRevisionWithOwnerAndSiblings
+
 // Phase represents a collection of objects lifecycled together.
 type Phase = types.Phase
 
@@ -36,6 +40,10 @@ var NewPhase = types.NewPhase
 
 // NewPhaseWithOwner creates a new PhaseBuilder with the given name, objects and owner.
 var NewPhaseWithOwner = types.NewPhaseWithOwner
+
+// NewPhaseWithOwnerAndSiblings creates a new PhaseBuilder with the given name, objects, owner
+// and sibling owners for revision handover.
+var NewPhaseWithOwnerAndSiblings = types.NewPhaseWithOwnerAndSiblings
 
 // ObjectReconcileOption is the common interface for object reconciliation options.
 type ObjectReconcileOption = types.ObjectReconcileOption
@@ -55,9 +63,18 @@ type RevisionReconcileOption = types.RevisionReconcileOption
 // RevisionTeardownOption holds configuration options changing revision teardown.
 type RevisionTeardownOption = types.RevisionTeardownOption
 
-// WithPreviousOwners is a list of known objects allowed to take ownership from.
-// Objects from this list will not trigger collision detection and prevention.
-type WithPreviousOwners = types.WithPreviousOwners
+// WithSiblingOwnerClassifier sets a callback to classify unknown controllers.
+// When the callback returns true, the unknown controller is treated as a
+// sibling revision of the same deployment instead of a collision.
+type WithSiblingOwnerClassifier = types.WithSiblingOwnerClassifier
+
+// WithSiblingOwners returns a WithSiblingOwnerClassifier option that
+// compares against UIDs of all passed `siblings` objects.
+var WithSiblingOwners = types.WithSiblingOwners
+
+// WithSiblingOwnerRefs returns a WithSiblingOwnerClassifier option that
+// compares against UIDs of all passed owner references.
+var WithSiblingOwnerRefs = types.WithSiblingOwnerRefs
 
 const (
 	// CollisionProtectionPrevent prevents owner collisions entirely

--- a/cmd/reference/internal/deploy.go
+++ b/cmd/reference/internal/deploy.go
@@ -421,7 +421,7 @@ func (c *Reconciler) toRevision(deployName string, cm *corev1.ConfigMap) (
 	)
 
 	opts = []boxcutter.RevisionReconcileOption{
-		boxcutter.WithPreviousOwners(previous),
+		boxcutter.WithSiblingOwners(previous),
 		boxcutter.WithProbe(
 			boxcutter.ProgressProbeType,
 			boxcutter.ProbeFunc(func(obj client.Object) probing.Result {

--- a/cmd/reference/internal/deploy.go
+++ b/cmd/reference/internal/deploy.go
@@ -38,7 +38,6 @@ const (
 	hashAnnotation      = "boxcutter.test/hash"
 	cmPhasesKey         = "phases"
 	cmRevisionNumberKey = "revision"
-	cmPreviousKey       = "previous"
 	cmStateKey          = "state"
 
 	revisionHistoryLimit = 5
@@ -128,7 +127,7 @@ func (c *Reconciler) handleDeployment(ctx context.Context, cm *corev1.ConfigMap)
 	existingRevisions := make([]boxcutter.Revision, 0, len(existingRevisionsRaw.Items))
 
 	for _, rev := range existingRevisionsRaw.Items {
-		r, _, _, err := c.toRevision(cm.Name, &rev)
+		r, _, err := c.toRevision(cm.Name, &rev, nil)
 		if err != nil {
 			return res, fmt.Errorf("to revision: %w", err)
 		}
@@ -180,7 +179,6 @@ func (c *Reconciler) handleDeployment(ctx context.Context, cm *corev1.ConfigMap)
 			Data: cm.Data,
 		}
 		newRevision.Data[cmRevisionNumberKey] = strconv.FormatInt(revisionNumber, 10)
-		newRevision.Data[cmPreviousKey] = prevJSON(prevRevisions)
 
 		if err := controllerutil.SetControllerReference(cm, newRevision, c.scheme); err != nil {
 			return res, fmt.Errorf("set ownerref: %w", err)
@@ -213,7 +211,25 @@ func (c *Reconciler) handleDeployment(ctx context.Context, cm *corev1.ConfigMap)
 func (c *Reconciler) handleRevision(
 	ctx context.Context, deploy *corev1.ConfigMap, revisionCM *corev1.ConfigMap,
 ) (res ctrl.Result, err error) {
-	revision, opts, previous, err := c.toRevision(deploy.Name, revisionCM)
+	siblingCMs := &corev1.ConfigMapList{}
+	if err := c.client.List(ctx, siblingCMs, client.MatchingLabels{
+		typeLabel:       "Revision",
+		deploymentLabel: deploy.Name,
+	}); err != nil {
+		return res, fmt.Errorf("listing sibling revisions: %w", err)
+	}
+
+	var siblings []client.Object
+
+	for i := range siblingCMs.Items {
+		if siblingCMs.Items[i].GetUID() == revisionCM.GetUID() {
+			continue
+		}
+
+		siblings = append(siblings, &siblingCMs.Items[i])
+	}
+
+	revision, opts, err := c.toRevision(deploy.Name, revisionCM, siblings)
 	if err != nil {
 		return res, fmt.Errorf("converting CM to revision: %w", err)
 	}
@@ -295,10 +311,21 @@ func (c *Reconciler) handleRevision(
 		}
 	}
 
-	// Archive other revisions.
+	// Archive previous revisions.
 	if rres.IsComplete() {
-		for _, a := range previous {
-			if err := c.client.Patch(ctx, a, client.RawPatch(
+		for _, s := range siblings {
+			siblingConfigMap := s.(*corev1.ConfigMap)
+
+			if siblingConfigMap.Data[cmStateKey] == "Archived" {
+				continue
+			}
+
+			siblingRevisionNumber, err := parseRevisionNumber(siblingConfigMap.Data[cmRevisionNumberKey])
+			if err != nil || siblingRevisionNumber >= revision.GetRevisionNumber() {
+				continue
+			}
+
+			if err := c.client.Patch(ctx, s, client.RawPatch(
 				types.MergePatchType, []byte(`{"data":{"state":"Archived"}}`))); err != nil {
 				return res, fmt.Errorf("archive previous Revision: %w", err)
 			}
@@ -331,13 +358,12 @@ func (e RevisionNumberNotSetError) Error() string {
 	return e.msg
 }
 
-func (c *Reconciler) toRevision(deployName string, cm *corev1.ConfigMap) (
-	r boxcutter.Revision, opts []boxcutter.RevisionReconcileOption, previous []client.Object, err error,
+func (c *Reconciler) toRevision(deployName string, cm *corev1.ConfigMap, siblings []client.Object) (
+	r boxcutter.Revision, opts []boxcutter.RevisionReconcileOption, err error,
 ) {
 	var (
-		phaseNames    []string
-		previousUnstr []unstructured.Unstructured
-		revision      int64
+		phaseNames []string
+		revision   int64
 	)
 
 	objects := map[string][]client.Object{}
@@ -345,7 +371,7 @@ func (c *Reconciler) toRevision(deployName string, cm *corev1.ConfigMap) (
 	for k, v := range cm.Data {
 		if k == cmPhasesKey {
 			if err := json.Unmarshal([]byte(v), &phaseNames); err != nil {
-				return nil, nil, nil, fmt.Errorf("json unmarshal key %s: %w", k, err)
+				return nil, nil, fmt.Errorf("json unmarshal key %s: %w", k, err)
 			}
 
 			continue
@@ -354,7 +380,7 @@ func (c *Reconciler) toRevision(deployName string, cm *corev1.ConfigMap) (
 		if k == cmRevisionNumberKey {
 			i, err := strconv.ParseInt(v, 10, 64)
 			if err != nil {
-				return nil, nil, nil, fmt.Errorf("parsing revision: %w", err)
+				return nil, nil, fmt.Errorf("parsing revision: %w", err)
 			}
 
 			revision = i
@@ -362,11 +388,7 @@ func (c *Reconciler) toRevision(deployName string, cm *corev1.ConfigMap) (
 			continue
 		}
 
-		if k == cmPreviousKey {
-			if err := json.Unmarshal([]byte(v), &previousUnstr); err != nil {
-				return nil, nil, nil, fmt.Errorf("json unmarshal key %s: %w", k, err)
-			}
-
+		if k == cmStateKey {
 			continue
 		}
 
@@ -379,7 +401,7 @@ func (c *Reconciler) toRevision(deployName string, cm *corev1.ConfigMap) (
 
 		obj := &unstructured.Unstructured{}
 		if err := json.Unmarshal([]byte(v), obj); err != nil {
-			return nil, nil, nil, fmt.Errorf("json unmarshal key %s: %w", k, err)
+			return nil, nil, fmt.Errorf("json unmarshal key %s: %w", k, err)
 		}
 
 		// Force namespace to the owner's namespace.
@@ -398,11 +420,7 @@ func (c *Reconciler) toRevision(deployName string, cm *corev1.ConfigMap) (
 	}
 
 	if revision == 0 {
-		return nil, nil, nil, RevisionNumberNotSetError{msg: "revision not set"}
-	}
-
-	for _, obj := range previousUnstr {
-		previous = append(previous, &obj)
+		return nil, nil, RevisionNumberNotSetError{msg: "revision not set"}
 	}
 
 	phases := make([]boxcutter.Phase, 0, len(phaseNames))
@@ -415,13 +433,13 @@ func (c *Reconciler) toRevision(deployName string, cm *corev1.ConfigMap) (
 		phases = append(phases, p)
 	}
 
-	rev := boxcutter.NewRevisionWithOwner(
+	rev := boxcutter.NewRevisionWithOwnerAndSiblings(
 		cm.Name, revision, phases,
 		cm, c.ownerStrategy,
+		siblings,
 	)
 
 	opts = []boxcutter.RevisionReconcileOption{
-		boxcutter.WithSiblingOwners(previous),
 		boxcutter.WithProbe(
 			boxcutter.ProgressProbeType,
 			boxcutter.ProbeFunc(func(obj client.Object) probing.Result {
@@ -447,7 +465,7 @@ func (c *Reconciler) toRevision(deployName string, cm *corev1.ConfigMap) (
 		opts = append(opts, boxcutter.WithPaused{})
 	}
 
-	return rev, opts, previous, nil
+	return rev, opts, nil
 }
 
 func (c *Reconciler) ensureFinalizer(

--- a/cmd/reference/internal/reference.go
+++ b/cmd/reference/internal/reference.go
@@ -23,7 +23,6 @@ import (
 const (
 	fieldOwner        = "boxcutter.test"
 	systemPrefix      = "boxcutter.test"
-	cacheFinalizer    = "boxcutter.test/cache"
 	teardownFinalizer = "boxcutter.test/teardown"
 	typeLabel         = "boxcutter.test/type"
 )
@@ -109,7 +108,7 @@ func (r *Reference) Start(ctx context.Context) error {
 		return c, o, nil
 	}
 
-	mc := managedcache.NewObjectBoundAccessManager[*corev1.ConfigMap](
+	mc := managedcache.NewObjectBoundAccessManager(
 		ctrl.Log,
 		mapper, r.restConfig, cache.Options{
 			Mapper: mgr.GetRESTMapper(),

--- a/cmd/reference/internal/util.go
+++ b/cmd/reference/internal/util.go
@@ -1,10 +1,9 @@
 package internal
 
 import (
-	"encoding/json"
+	"strconv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"pkg.package-operator.run/boxcutter"
@@ -30,25 +29,8 @@ func latestRevisionNumber(prevRevisions []bctypes.Revision) int64 {
 	return prevRevisions[len(prevRevisions)-1].GetRevisionNumber()
 }
 
-func prevJSON(prevRevisions []bctypes.Revision) string {
-	data := make([]unstructured.Unstructured, 0, len(prevRevisions))
-
-	for _, rev := range prevRevisions {
-		refObj := getOwnerFromRev(rev)
-		ref := unstructured.Unstructured{}
-		ref.SetGroupVersionKind(refObj.GetObjectKind().GroupVersionKind())
-		ref.SetName(refObj.GetName())
-		ref.SetNamespace(refObj.GetNamespace())
-		ref.SetUID(refObj.GetUID())
-		data = append(data, ref)
-	}
-
-	dataJSON, err := json.Marshal(data)
-	if err != nil {
-		panic(err)
-	}
-
-	return string(dataJSON)
+func parseRevisionNumber(raw string) (int64, error) {
+	return strconv.ParseInt(raw, 10, 64)
 }
 
 func getOwner(obj client.Object) (metav1.OwnerReference, bool) {

--- a/machinery/objects.go
+++ b/machinery/objects.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -404,6 +405,16 @@ func (e *ObjectEngine) objectUpdateHandling(
 		// This should not happen - the current owner has been classified as a sibling
 		// but the object's revision is the same as the desired revision we're reconciling here.
 		// Must be a user or data error. Surface as conflict.
+		log := logr.FromContextOrDiscard(ctx)
+		log.WithName("objectEngine").Info("update conflict without revision change",
+			"revision", revision,
+			"actualObjectRevision", actualObjectRevision,
+			"gvk", actualObject.GetObjectKind().GroupVersionKind().String(),
+			"namespace", actualObject.GetNamespace(),
+			"name", actualObject.GetName(),
+			"ownerName", actualOwner.Name,
+		)
+
 		return newObjectResultConflict(
 			actualObject, compareRes,
 			actualOwner, options,

--- a/machinery/objects.go
+++ b/machinery/objects.go
@@ -170,6 +170,7 @@ func (e *ObjectEngine) Teardown(
 			patch := actualObject.DeepCopyObject().(Object)
 			options.OwnerStrategy.RemoveOwner(options.Owner, patch)
 
+			// TODO should we check if the patch differs from actualObject before firing the request?
 			return true, e.writer.Patch(ctx, patch, client.MergeFrom(actualObject))
 		}
 	}
@@ -314,7 +315,8 @@ func (e *ObjectEngine) checkSituation(
 
 	if options.Owner != nil {
 		ctrlSit, actualOwner = e.detectOwner(
-			options.Owner, options.OwnerStrategy, actualObject, options.PreviousOwners)
+			options.Owner, options.OwnerStrategy,
+			actualObject, options.SiblingOwnerClassifier)
 
 		compareOpts = append(compareOpts, types.WithOwner(options.Owner, options.OwnerStrategy))
 	} else {
@@ -325,9 +327,6 @@ func (e *ObjectEngine) checkSituation(
 		}
 	}
 
-	// An object already exists on the cluster.
-	// Before doing anything else, we have to figure out
-	// who owns and controls the object.
 	compareRes, err = e.comparator.Compare(desiredObject, actualObject, compareOpts...)
 	if err != nil {
 		err = fmt.Errorf("diverge check: %w", err)
@@ -364,20 +363,53 @@ func (e *ObjectEngine) objectUpdateHandling(
 	}
 
 	switch ctrlSit {
-	case ctrlSituationIsController:
-		// Ensure revision linearity.
-		// Only skip reconciliation for a newer revision when we are
-		// already the controller or a previous owner is the controller.
-		// For unknown or absent controllers, collision protection must
-		// be evaluated first.
+	case ctrlSituationUnknownController:
+		if options.CollisionProtection != types.CollisionProtectionNone {
+			return newObjectResultConflict(
+				actualObject, compareRes,
+				actualOwner, options,
+			), nil
+		}
+
+		return e.objectAdoptionHandling(ctx, compareRes, revision, desiredObject, actualObject, options)
+
+	case ctrlSituationNoController:
+		// If the object has no controller, but there are system annotations or labels present,
+		// the object might have been just orphaned, if we re-adopt it now, it would get deleted
+		// by the kubernetes garbage collector.
+		if options.CollisionProtection == types.CollisionProtectionPrevent ||
+			e.isBoxcutterManaged(actualObject) {
+			return newObjectResultConflict(
+				actualObject, compareRes,
+				actualOwner, options,
+			), nil
+		}
+
+		return e.objectAdoptionHandling(ctx, compareRes, revision, desiredObject, actualObject, options)
+
+	case ctrlSituationSiblingIsController:
 		if actualObjectRevision > revision {
-			// Leave object alone.
-			// It's already owned by a later revision.
+			// A newer sibling revision already owns this object. Report progress.
 			return newObjectResultProgressed(
 				actualObject, compareRes, options,
 			), nil
 		}
 
+		if actualObjectRevision < revision {
+			// An older sibling revision currently owns this object. Adopt it.
+			return e.objectAdoptionHandling(ctx, compareRes, revision, desiredObject, actualObject, options)
+		}
+
+		// actualObjectRevision == revision
+		// This should not happen - the current owner has been classified as a sibling
+		// but the object's revision is the same as the desired revision we're reconciling here.
+		// Must be a user or data error. Surface as conflict.
+		return newObjectResultConflict(
+			actualObject, compareRes,
+			actualOwner, options,
+		), nil
+
+	case ctrlSituationIsController:
 		modified := compareRes.Comparison != nil &&
 			(!compareRes.Comparison.Modified.Empty() ||
 				!compareRes.Comparison.Removed.Empty())
@@ -443,50 +475,18 @@ func (e *ObjectEngine) objectUpdateHandling(
 			desiredObject, compareRes, options,
 		), nil
 
-		// Taking control checklist:
-		// - current controlling owner MUST be in PreviousOwners list
-		//   - OR object has _no_ controlling owner and CollisionProtection set to IfNoController or None
-		//   - OR object has another controlling owner and Collision Protection is set to None
-		//
-		// If any of the above points is not true, refuse.
-
-	case ctrlSituationUnknownController:
-		if options.CollisionProtection != types.CollisionProtectionNone {
-			return newObjectResultConflict(
-				actualObject, compareRes,
-				actualOwner, options,
-			), nil
-		}
-
-	case ctrlSituationNoController:
-		// If the object has no controller, but there are system annotations or labels present,
-		// the object might have been just orphaned, if we re-adopt it now, it would get deleted
-		// by the kubernetes garbage collector.
-		if options.CollisionProtection == types.CollisionProtectionPrevent ||
-			e.isBoxcutterManaged(actualObject) {
-			return newObjectResultConflict(
-				actualObject, compareRes,
-				actualOwner, options,
-			), nil
-		}
-
-	case ctrlSituationPreviousIsController:
-		// no extra operation
-		break
+	default:
+		panic(fmt.Sprintf("ObjectEngine.objectUpdateHandling encountered unknown ctrlSituation: %s", ctrlSit))
 	}
+}
 
-	// A previous revision is current controller.
-	// This means we want to take control, but
-	// retain older revisions ownerReferences,
-	// so they can still react to events.
-
-	// Ensure revision linearity
-	if actualObjectRevision > revision {
-		return newObjectResultProgressed(
-			actualObject, compareRes, options,
-		), nil
-	}
-
+func (e *ObjectEngine) objectAdoptionHandling(ctx context.Context,
+	compareRes CompareResult,
+	revision int64,
+	desiredObject Object,
+	actualObject Object,
+	options types.ObjectReconcileOptions,
+) (ObjectResult, error) {
 	// TODO:
 	// ObjectResult ModifiedFields does not contain ownerReference changes
 	// introduced here, this may lead to Updated Actions without modifications.
@@ -504,7 +504,7 @@ func (e *ObjectEngine) objectUpdateHandling(
 	}
 
 	// Write changes.
-	err = e.apply(
+	err := e.apply(
 		ctx, desiredObject, actualObject,
 		options,
 		client.ForceOwnership,
@@ -594,10 +594,10 @@ type ctrlSituation string
 const (
 	// Owner is already controller.
 	ctrlSituationIsController ctrlSituation = "IsController"
-	// Previous revision/previous owner is controller.
-	ctrlSituationPreviousIsController ctrlSituation = "PreviousIsController"
+	// Sibling revision of the same deployment is controller,
+	// as classified by the SiblingOwnerClassifier callback.
+	ctrlSituationSiblingIsController ctrlSituation = "SiblingIsController"
 	// Someone else is controller of this object.
-	// This includes the "next" revision, as it's not in "previousOwners".
 	ctrlSituationUnknownController ctrlSituation = "UnknownController"
 	// No controller found.
 	ctrlSituationNoController ctrlSituation = "NoController"
@@ -607,7 +607,7 @@ func (e *ObjectEngine) detectOwner(
 	owner client.Object,
 	ownerStrategy objectEngineOwnerStrategy,
 	actualObject Object,
-	previousOwners []client.Object,
+	siblingOwnerClassifier types.SiblingOwnerClassifierFunc,
 ) (ctrlSituation, *metav1.OwnerReference) {
 	// e.ownerStrategy may either work on .metadata.ownerReferences or
 	// on an annotation to allow cross-namespace and cross-cluster refs.
@@ -616,22 +616,15 @@ func (e *ObjectEngine) detectOwner(
 		return ctrlSituationNoController, nil
 	}
 
-	// Are we already controller?
-	if ownerStrategy.IsController(owner, actualObject) {
+	switch {
+	case ownerStrategy.IsController(owner, actualObject):
+		// We already are controller.
 		return ctrlSituationIsController, &ownerRef
+	case siblingOwnerClassifier != nil && siblingOwnerClassifier(ownerRef):
+		return ctrlSituationSiblingIsController, &ownerRef
+	default:
+		return ctrlSituationUnknownController, &ownerRef
 	}
-
-	// Check if previous owner is controller.
-	for _, previousOwner := range previousOwners {
-		if ownerStrategy.IsController(previousOwner, actualObject) {
-			return ctrlSituationPreviousIsController, &ownerRef
-		}
-	}
-
-	// Anyone else controller?
-	// This statement can only resolve to true if annotations
-	// are used for owner reference tracking.
-	return ctrlSituationUnknownController, &ownerRef
 }
 
 // Stores the revision number in a well-known annotation on the given object.

--- a/machinery/objects_test.go
+++ b/machinery/objects_test.go
@@ -204,6 +204,24 @@ func TestObjectEngine(t *testing.T) {
 		afterAssert func(t *testing.T, writer *testutil.CtrlClient)
 	}
 
+	mockSetupCacheGetAndCompare := func(
+		cache *cacheMock, _ *testutil.CtrlClient,
+		ddm *comparatorMock, actualObject *unstructured.Unstructured,
+	) {
+		cache.
+			On("Get", mock.Anything,
+				client.ObjectKeyFromObject(actualObject),
+				mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				obj := args.Get(2).(*unstructured.Unstructured)
+				*obj = *actualObject
+			}).
+			Return(nil)
+		ddm.
+			On("Compare", mock.Anything, mock.Anything, mock.Anything).
+			Return(CompareResult{}, nil)
+	}
+
 	sharedTests := []sharedTestCase{
 		{
 			name:           "Created",
@@ -327,11 +345,11 @@ func TestObjectEngine(t *testing.T) {
 			expectedAction: ActionRecovered,
 		},
 		{
-			name:           "Progressed",
+			name:           "Recovered - isController revision annotation drift",
 			revision:       1,
 			desiredObject:  buildObj("testi", "test"),
 			actualObject:   buildObj("testi", "test", withRevision("4"), withManaged),
-			expectedObject: buildObj("testi", "test", withRevision("4"), withManaged),
+			expectedObject: buildObj("testi", "test", withRevision("1"), withManaged),
 			modes:          []ownerMode{withNativeOwnerMode},
 			mockSetup: func(
 				cache *cacheMock, writer *testutil.CtrlClient,
@@ -348,15 +366,19 @@ func TestObjectEngine(t *testing.T) {
 					Return(nil)
 				ddm.
 					On("Compare", mock.Anything, mock.Anything, mock.Anything).
-					Return(CompareResult{}, nil)
+					Return(CompareResult{
+						ConflictingMangers: []CompareResultManagedFields{
+							{Manager: "external-patcher"},
+						},
+					}, nil)
 				writer.
-					On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					On("Apply", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
 			},
-			expectedAction: ActionProgressed,
+			expectedAction: ActionRecovered,
 		},
 		{
-			name:          "Progressed - previousOwner higher revision",
+			name:          "Progressed - sibling owner higher revision",
 			revision:      1,
 			desiredObject: buildObj("testi", "test"),
 			actualObject: buildObj("testi", "test", withRevision("4"),
@@ -365,29 +387,11 @@ func TestObjectEngine(t *testing.T) {
 				withOwnerRef("v1", "ConfigMap", "old-owner", "6789", true)),
 			modes: []ownerMode{withNativeOwnerMode},
 			opts: []types.ObjectReconcileOption{
-				types.WithPreviousOwners{&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						UID: "6789", Name: "old-owner", Namespace: "test",
-					},
-				}},
+				types.WithSiblingOwnerRefs([]metav1.OwnerReference{
+					{UID: "6789"},
+				}),
 			},
-			mockSetup: func(
-				cache *cacheMock, writer *testutil.CtrlClient,
-				ddm *comparatorMock, actualObject *unstructured.Unstructured,
-			) {
-				cache.
-					On("Get", mock.Anything,
-						client.ObjectKeyFromObject(actualObject),
-						mock.Anything, mock.Anything).
-					Run(func(args mock.Arguments) {
-						obj := args.Get(2).(*unstructured.Unstructured)
-						*obj = *actualObject
-					}).
-					Return(nil)
-				ddm.
-					On("Compare", mock.Anything, mock.Anything, mock.Anything).
-					Return(CompareResult{}, nil)
-			},
+			mockSetup:      mockSetupCacheGetAndCompare,
 			expectedAction: ActionProgressed,
 		},
 		{
@@ -442,6 +446,40 @@ func TestObjectEngine(t *testing.T) {
 					On("Compare", mock.Anything, mock.Anything, mock.Anything).
 					Return(CompareResult{}, nil)
 			},
+			expectedAction: ActionCollision,
+		},
+		{
+			name:          "Progressed - sibling owner higher revision via classifier",
+			revision:      1,
+			desiredObject: buildObj("testi", "test"),
+			actualObject: buildObj("testi", "test", withRevision("4"),
+				withOwnerRef("v1", "ConfigMap", "future-owner", "9999", true)),
+			expectedObject: buildObj("testi", "test", withRevision("4"),
+				withOwnerRef("v1", "ConfigMap", "future-owner", "9999", true)),
+			modes: []ownerMode{withNativeOwnerMode},
+			opts: []types.ObjectReconcileOption{
+				types.WithSiblingOwnerRefs([]metav1.OwnerReference{
+					{UID: "9999"},
+				}),
+			},
+			mockSetup:      mockSetupCacheGetAndCompare,
+			expectedAction: ActionProgressed,
+		},
+		{
+			name:          "Collision - sibling owner same revision via classifier",
+			revision:      1,
+			desiredObject: buildObj("testi", "test"),
+			actualObject: buildObj("testi", "test", withRevision("1"),
+				withOwnerRef("v1", "ConfigMap", "future-owner", "9999", true)),
+			expectedObject: buildObj("testi", "test", withRevision("1"),
+				withOwnerRef("v1", "ConfigMap", "future-owner", "9999", true)),
+			modes: []ownerMode{withNativeOwnerMode},
+			opts: []types.ObjectReconcileOption{
+				types.WithSiblingOwnerClassifier(func(ownerRef metav1.OwnerReference) bool {
+					return ownerRef.UID == "9999"
+				}),
+			},
+			mockSetup:      mockSetupCacheGetAndCompare,
 			expectedAction: ActionCollision,
 		},
 		{ //nolint:dupl // Similar to CollisionProtectionNone test
@@ -528,20 +566,18 @@ func TestObjectEngine(t *testing.T) {
 			expectedError: "diverge check",
 		},
 		{
-			name:          "Updated takeover from previousOwner",
-			revision:      1,
+			name:          "Updated takeover from sibling owner",
+			revision:      2,
 			desiredObject: buildObj("testi", "test"),
 			actualObject: buildObj("testi", "test", withRevision("1"),
 				withOwnerRef("v1", "ConfigMap", "old-owner", "6789", true)),
-			expectedObject: buildObj("testi", "test", withRevision("1"),
+			expectedObject: buildObj("testi", "test", withRevision("2"),
 				withOwnerRef("v1", "ConfigMap", "old-owner", "6789", false), withManaged),
 			modes: []ownerMode{withNativeOwnerMode},
 			opts: []types.ObjectReconcileOption{
-				types.WithPreviousOwners{&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						UID: "6789", Name: "old-owner", Namespace: "test",
-					},
-				}},
+				types.WithSiblingOwnerRefs([]metav1.OwnerReference{
+					{UID: "6789"},
+				}),
 			},
 			mockSetup: func(
 				cache *cacheMock, writer *testutil.CtrlClient,
@@ -806,7 +842,7 @@ func TestObjectEngine(t *testing.T) {
 		},
 		{
 			name:          "Paused, takeover returns actual",
-			revision:      1,
+			revision:      2,
 			desiredObject: buildObj("testi", "test"),
 			actualObject: buildObj("testi", "test", withRevision("1"),
 				withResourceVersion("888"),
@@ -817,11 +853,9 @@ func TestObjectEngine(t *testing.T) {
 			modes: []ownerMode{withNativeOwnerMode},
 			opts: []types.ObjectReconcileOption{
 				types.WithPaused{},
-				types.WithPreviousOwners{&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						UID: "6789", Name: "old-owner", Namespace: "test",
-					},
-				}},
+				types.WithSiblingOwnerRefs([]metav1.OwnerReference{
+					{UID: "6789"},
+				}),
 			},
 			mockSetup: func(
 				cache *cacheMock, _ *testutil.CtrlClient,

--- a/machinery/types/options.go
+++ b/machinery/types/options.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -117,14 +118,19 @@ type PhaseTeardownOption interface {
 	RevisionTeardownOption
 }
 
+// SiblingOwnerClassifierFunc is called when an object is controlled by an
+// unknown owner. Returns true if the owner belongs to the same deployment
+// and should be treated as a sibling revision instead of a collision.
+type SiblingOwnerClassifierFunc func(ownerRef metav1.OwnerReference) bool
+
 // ObjectReconcileOptions holds configuration options changing object reconciliation.
 type ObjectReconcileOptions struct {
-	CollisionProtection CollisionProtection
-	PreviousOwners      []client.Object
-	Owner               client.Object
-	OwnerStrategy       OwnerStrategy
-	Paused              bool
-	Probes              map[string]Prober
+	CollisionProtection    CollisionProtection
+	SiblingOwnerClassifier SiblingOwnerClassifierFunc
+	Owner                  client.Object
+	OwnerStrategy          OwnerStrategy
+	Paused                 bool
+	Probes                 map[string]Prober
 }
 
 // Default sets empty Option fields to their default value.
@@ -147,7 +153,7 @@ type ObjectReconcileOption interface {
 var (
 	_ ObjectReconcileOption = (WithCollisionProtection)("")
 	_ ObjectReconcileOption = (WithPaused{})
-	_ ObjectReconcileOption = (WithPreviousOwners{})
+	_ ObjectReconcileOption = (WithSiblingOwnerClassifier)(nil)
 	_ ObjectReconcileOption = (WithProbe("", nil))
 	_ ObjectTeardownOption  = (WithTeardownWriter(nil))
 )
@@ -211,23 +217,57 @@ func (p WithCollisionProtection) ApplyToRevisionReconcileOptions(opts *RevisionR
 	opts.DefaultPhaseOptions = append(opts.DefaultPhaseOptions, p)
 }
 
-// WithPreviousOwners is a list of known objects allowed to take ownership from.
-// Objects from this list will not trigger collision detection and prevention.
-type WithPreviousOwners []client.Object
+// WithSiblingOwnerClassifier sets a callback to classify unknown controllers.
+// When the callback returns true, the unknown controller is treated as a
+// sibling revision of the same deployment instead of a collision.
+type WithSiblingOwnerClassifier SiblingOwnerClassifierFunc
 
 // ApplyToObjectReconcileOptions implements ObjectReconcileOption.
-func (p WithPreviousOwners) ApplyToObjectReconcileOptions(opts *ObjectReconcileOptions) {
-	opts.PreviousOwners = p
+func (p WithSiblingOwnerClassifier) ApplyToObjectReconcileOptions(opts *ObjectReconcileOptions) {
+	opts.SiblingOwnerClassifier = SiblingOwnerClassifierFunc(p)
 }
 
 // ApplyToPhaseReconcileOptions implements PhaseOption.
-func (p WithPreviousOwners) ApplyToPhaseReconcileOptions(opts *PhaseReconcileOptions) {
+func (p WithSiblingOwnerClassifier) ApplyToPhaseReconcileOptions(opts *PhaseReconcileOptions) {
 	opts.DefaultObjectOptions = append(opts.DefaultObjectOptions, p)
 }
 
 // ApplyToRevisionReconcileOptions implements RevisionReconcileOptions.
-func (p WithPreviousOwners) ApplyToRevisionReconcileOptions(opts *RevisionReconcileOptions) {
+func (p WithSiblingOwnerClassifier) ApplyToRevisionReconcileOptions(opts *RevisionReconcileOptions) {
 	opts.DefaultPhaseOptions = append(opts.DefaultPhaseOptions, p)
+}
+
+// WithSiblingOwners returns a WithSiblingOwnerClassifier option that
+// compares against UIDs of all passed `siblings` objects.
+func WithSiblingOwners(siblings []client.Object) WithSiblingOwnerClassifier {
+	uids := make([]types.UID, 0, len(siblings))
+	for _, sibling := range siblings {
+		uids = append(uids, sibling.GetUID())
+	}
+
+	return func(actualOwnerRef metav1.OwnerReference) bool {
+		for _, uid := range uids {
+			if actualOwnerRef.UID == uid {
+				return true
+			}
+		}
+
+		return false
+	}
+}
+
+// WithSiblingOwnerRefs returns a WithSiblingOwnerClassifier option that
+// compares against UIDs of all passed owner references.
+func WithSiblingOwnerRefs(ownerRefs []metav1.OwnerReference) WithSiblingOwnerClassifier {
+	return func(actualOwnerRef metav1.OwnerReference) bool {
+		for _, ownerRef := range ownerRefs {
+			if actualOwnerRef.UID == ownerRef.UID {
+				return true
+			}
+		}
+
+		return false
+	}
 }
 
 // WithPaused skips reconciliation and just reports status information.

--- a/machinery/types/options.go
+++ b/machinery/types/options.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"slices"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -246,13 +248,7 @@ func WithSiblingOwners(siblings []client.Object) WithSiblingOwnerClassifier {
 	}
 
 	return func(actualOwnerRef metav1.OwnerReference) bool {
-		for _, uid := range uids {
-			if actualOwnerRef.UID == uid {
-				return true
-			}
-		}
-
-		return false
+		return slices.Contains(uids, actualOwnerRef.UID)
 	}
 }
 

--- a/machinery/types/options_test.go
+++ b/machinery/types/options_test.go
@@ -287,6 +287,57 @@ func TestWithSiblingOwnerClassifier(t *testing.T) {
 	})
 }
 
+func TestWithSiblingOwnerConvenienceConstructors(t *testing.T) {
+	t.Parallel()
+
+	matchUID := metav1.OwnerReference{UID: "uid-1"}
+	unknownUID := metav1.OwnerReference{UID: "uid-unknown"}
+
+	applyClassifier := func(t *testing.T, classifier WithSiblingOwnerClassifier) SiblingOwnerClassifierFunc {
+		t.Helper()
+
+		opts := &ObjectReconcileOptions{}
+		classifier.ApplyToObjectReconcileOptions(opts)
+		require.NotNil(t, opts.SiblingOwnerClassifier)
+
+		return opts.SiblingOwnerClassifier
+	}
+
+	t.Run("WithSiblingOwners", func(t *testing.T) {
+		t.Parallel()
+
+		siblings := []client.Object{
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{UID: "uid-1"}},
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{UID: "uid-2"}},
+		}
+
+		classify := applyClassifier(t, WithSiblingOwners(siblings))
+		assert.True(t, classify(matchUID))
+		assert.True(t, classify(metav1.OwnerReference{UID: "uid-2"}))
+		assert.False(t, classify(unknownUID))
+
+		emptyClassify := applyClassifier(t, WithSiblingOwners([]client.Object{}))
+		assert.False(t, emptyClassify(matchUID))
+	})
+
+	t.Run("WithSiblingOwnerRefs", func(t *testing.T) {
+		t.Parallel()
+
+		refs := []metav1.OwnerReference{
+			{UID: "uid-1"},
+			{UID: "uid-2"},
+		}
+
+		classify := applyClassifier(t, WithSiblingOwnerRefs(refs))
+		assert.True(t, classify(matchUID))
+		assert.True(t, classify(metav1.OwnerReference{UID: "uid-2"}))
+		assert.False(t, classify(unknownUID))
+
+		emptyClassify := applyClassifier(t, WithSiblingOwnerRefs([]metav1.OwnerReference{}))
+		assert.False(t, emptyClassify(matchUID))
+	})
+}
+
 func TestWithPaused(t *testing.T) {
 	t.Parallel()
 

--- a/machinery/types/options_test.go
+++ b/machinery/types/options_test.go
@@ -253,48 +253,37 @@ func TestWithCollisionProtection(t *testing.T) {
 	})
 }
 
-func TestWithPreviousOwners(t *testing.T) {
+func TestWithSiblingOwnerClassifier(t *testing.T) {
 	t.Parallel()
 
-	owner1 := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "owner1",
-			Namespace: "test",
-		},
-	}
-	owner2 := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "owner2",
-			Namespace: "test",
-		},
-	}
-
-	previousOwners := WithPreviousOwners{owner1, owner2}
+	classifier := WithSiblingOwnerClassifier(func(ref metav1.OwnerReference) bool {
+		return ref.UID == "test-uid"
+	})
 
 	t.Run("applies to object reconcile options", func(t *testing.T) {
 		t.Parallel()
 
 		opts := &ObjectReconcileOptions{}
-		previousOwners.ApplyToObjectReconcileOptions(opts)
-		assert.Equal(t, []client.Object{owner1, owner2}, opts.PreviousOwners)
+		classifier.ApplyToObjectReconcileOptions(opts)
+		require.NotNil(t, opts.SiblingOwnerClassifier)
+		assert.True(t, opts.SiblingOwnerClassifier(metav1.OwnerReference{UID: "test-uid"}))
+		assert.False(t, opts.SiblingOwnerClassifier(metav1.OwnerReference{UID: "other-uid"}))
 	})
 
 	t.Run("applies to phase reconcile options", func(t *testing.T) {
 		t.Parallel()
 
 		opts := &PhaseReconcileOptions{}
-		previousOwners.ApplyToPhaseReconcileOptions(opts)
+		classifier.ApplyToPhaseReconcileOptions(opts)
 		require.Len(t, opts.DefaultObjectOptions, 1)
-		assert.Equal(t, previousOwners, opts.DefaultObjectOptions[0])
 	})
 
 	t.Run("applies to revision reconcile options", func(t *testing.T) {
 		t.Parallel()
 
 		opts := &RevisionReconcileOptions{}
-		previousOwners.ApplyToRevisionReconcileOptions(opts)
+		classifier.ApplyToRevisionReconcileOptions(opts)
 		require.Len(t, opts.DefaultPhaseOptions, 1)
-		assert.Equal(t, previousOwners, opts.DefaultPhaseOptions[0])
 	})
 }
 
@@ -540,19 +529,25 @@ func TestInterfaceImplementations(t *testing.T) {
 
 	var _ ObjectReconcileOption = WithPaused{}
 
-	var _ ObjectReconcileOption = WithPreviousOwners{}
+	var _ ObjectReconcileOption = WithSiblingOwnerClassifier(nil)
+
+	var _ ObjectReconcileOption = WithSiblingOwnerRefs([]metav1.OwnerReference{})
 
 	var _ PhaseReconcileOption = WithCollisionProtection("")
 
 	var _ PhaseReconcileOption = WithPaused{}
 
-	var _ PhaseReconcileOption = WithPreviousOwners{}
+	var _ PhaseReconcileOption = WithSiblingOwnerClassifier(nil)
+
+	var _ PhaseReconcileOption = WithSiblingOwnerRefs([]metav1.OwnerReference{})
 
 	var _ RevisionReconcileOption = WithCollisionProtection("")
 
 	var _ RevisionReconcileOption = WithPaused{}
 
-	var _ RevisionReconcileOption = WithPreviousOwners{}
+	var _ RevisionReconcileOption = WithSiblingOwnerClassifier(nil)
+
+	var _ RevisionReconcileOption = WithSiblingOwnerRefs([]metav1.OwnerReference{})
 }
 
 func TestWithOrphan(t *testing.T) {

--- a/machinery/types/types.go
+++ b/machinery/types/types.go
@@ -74,6 +74,24 @@ func NewPhaseWithOwner(
 	return p.WithReconcileOptions(oo).WithTeardownOptions(oo)
 }
 
+// NewPhaseWithOwnerAndSiblings creates a new PhaseBuilder with the given name, objects, owner
+// and sibling owners for revision handover.
+func NewPhaseWithOwnerAndSiblings(
+	name string, objects []client.Object,
+	owner client.Object, ownerStrat OwnerStrategy,
+	siblings []client.Object,
+) PhaseBuilder {
+	oo := WithOwner(owner, ownerStrat)
+	p := &phase{
+		Name:    name,
+		Objects: objects,
+	}
+
+	return p.
+		WithReconcileOptions(oo, WithSiblingOwners(siblings)).
+		WithTeardownOptions(oo)
+}
+
 // phase represents a named collection of objects.
 type phase struct {
 	// Name of the Phase.
@@ -172,6 +190,27 @@ func NewRevisionWithOwner(
 	}
 
 	return r.WithReconcileOptions(oo).WithTeardownOptions(oo)
+}
+
+// NewRevisionWithOwnerAndSiblings creates a new RevisionBuilder
+// with the given name, rev, phases, owner and sibling owners for revision handover.
+func NewRevisionWithOwnerAndSiblings(
+	name string,
+	revNumber int64,
+	phases []Phase,
+	owner client.Object, ownerStrat OwnerStrategy,
+	siblings []client.Object,
+) RevisionBuilder {
+	oo := WithOwner(owner, ownerStrat)
+	r := &revision{
+		Name:     name,
+		Revision: revNumber,
+		Phases:   phases,
+	}
+
+	return r.
+		WithReconcileOptions(oo, WithSiblingOwners(siblings)).
+		WithTeardownOptions(oo)
 }
 
 // revision represents the version of a content collection consisting of phases.

--- a/machinery/types/types_test.go
+++ b/machinery/types/types_test.go
@@ -445,3 +445,59 @@ func TestNewRevisionWithOwner(t *testing.T) {
 	teardownOpts := revision.GetTeardownOptions()
 	assert.NotEmpty(t, teardownOpts)
 }
+
+func TestNewWithOwnerAndSiblings(t *testing.T) {
+	t.Parallel()
+
+	owner := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "owner",
+			Namespace: "test-ns",
+			UID:       "owner-uid",
+		},
+	}
+
+	siblings := []client.Object{
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{UID: "sibling-1"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{UID: "sibling-2"}},
+	}
+
+	mockStrat := &mockOwnerStrategy{}
+
+	t.Run("Phase", func(t *testing.T) {
+		t.Parallel()
+
+		objects := []client.Object{
+			&unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata":   map[string]interface{}{"name": "test-cm"},
+				},
+			},
+		}
+
+		phase := NewPhaseWithOwnerAndSiblings("test-phase", objects, owner, mockStrat, siblings)
+
+		assert.Equal(t, "test-phase", phase.GetName())
+		assert.Equal(t, objects, phase.GetObjects())
+		assert.Len(t, phase.GetReconcileOptions(), 2, "should have owner + sibling classifier")
+		assert.Len(t, phase.GetTeardownOptions(), 1, "should have owner only")
+	})
+
+	t.Run("Revision", func(t *testing.T) {
+		t.Parallel()
+
+		phases := []Phase{
+			NewPhase("phase1", []client.Object{}),
+		}
+
+		revision := NewRevisionWithOwnerAndSiblings("test-revision", 1, phases, owner, mockStrat, siblings)
+
+		assert.Equal(t, "test-revision", revision.GetName())
+		assert.Equal(t, int64(1), revision.GetRevisionNumber())
+		assert.Equal(t, phases, revision.GetPhases())
+		assert.Len(t, revision.GetReconcileOptions(), 2, "should have owner + sibling classifier")
+		assert.Len(t, revision.GetTeardownOptions(), 1, "should have owner only")
+	})
+}

--- a/machinery/types/types_test.go
+++ b/machinery/types/types_test.go
@@ -46,10 +46,10 @@ func TestToObjectRef(t *testing.T) {
 		{
 			name: "Unstructured object",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "test-deploy",
 						"namespace": "test-ns",
 					},
@@ -153,10 +153,10 @@ func TestPhase_GetName(t *testing.T) {
 
 	phase := NewPhase("test-phase", []client.Object{
 		&unstructured.Unstructured{
-			Object: map[string]interface{}{
+			Object: map[string]any{
 				"apiVersion": "v1",
 				"kind":       "ConfigMap",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name": "test-cm",
 				},
 			},
@@ -171,19 +171,19 @@ func TestPhase_GetObjects(t *testing.T) {
 
 	objects := []client.Object{
 		&unstructured.Unstructured{
-			Object: map[string]interface{}{
+			Object: map[string]any{
 				"apiVersion": "v1",
 				"kind":       "ConfigMap",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name": "test-cm",
 				},
 			},
 		},
 		&unstructured.Unstructured{
-			Object: map[string]interface{}{
+			Object: map[string]any{
 				"apiVersion": "v1",
 				"kind":       "Secret",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name": "test-secret",
 				},
 			},
@@ -225,10 +225,10 @@ func TestRevision_GetPhases(t *testing.T) {
 			Name: "phase1",
 			Objects: []client.Object{
 				&unstructured.Unstructured{
-					Object: map[string]interface{}{
+					Object: map[string]any{
 						"apiVersion": "v1",
 						"kind":       "ConfigMap",
-						"metadata": map[string]interface{}{
+						"metadata": map[string]any{
 							"name": "test-cm",
 						},
 					},
@@ -239,10 +239,10 @@ func TestRevision_GetPhases(t *testing.T) {
 			Name: "phase2",
 			Objects: []client.Object{
 				&unstructured.Unstructured{
-					Object: map[string]interface{}{
+					Object: map[string]any{
 						"apiVersion": "v1",
 						"kind":       "Secret",
-						"metadata": map[string]interface{}{
+						"metadata": map[string]any{
 							"name": "test-secret",
 						},
 					},
@@ -336,10 +336,10 @@ func TestNewPhaseWithOwner(t *testing.T) {
 
 	objects := []client.Object{
 		&unstructured.Unstructured{
-			Object: map[string]interface{}{
+			Object: map[string]any{
 				"apiVersion": "v1",
 				"kind":       "ConfigMap",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name": "test-cm",
 				},
 			},
@@ -469,10 +469,10 @@ func TestNewWithOwnerAndSiblings(t *testing.T) {
 
 		objects := []client.Object{
 			&unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": "v1",
 					"kind":       "ConfigMap",
-					"metadata":   map[string]interface{}{"name": "test-cm"},
+					"metadata":   map[string]any{"name": "test-cm"},
 				},
 			},
 		}

--- a/test/objects_test.go
+++ b/test/objects_test.go
@@ -144,6 +144,78 @@ Comparison:
 	assert.True(t, gone)
 }
 
+func TestObjectEngine_IsControllerRevisionAnnotationDrift(t *testing.T) {
+	os := ownerhandling.NewNative(Scheme)
+	comp := machinery.NewComparator(DiscoveryClient, Scheme, fieldOwner)
+	oe := machinery.NewObjectEngine(
+		Scheme, Client, Client, comp, fieldOwner, systemPrefix, "", nil,
+	)
+
+	ctx := t.Context()
+	owner := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "oe-rev-drift-owner",
+				"namespace": "default",
+			},
+		},
+	}
+	require.NoError(t, Client.Create(ctx, owner, client.FieldOwner(fieldOwner)))
+	cleanupOnSuccess(t, owner)
+
+	configMap := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "oe-rev-drift-test",
+				"namespace": "default",
+			},
+			"data": map[string]interface{}{
+				"key": "value",
+			},
+		},
+	}
+
+	// Create the object at revision 1.
+	res, err := oe.Reconcile(ctx, 1, configMap, types.WithOwner(owner, os))
+	require.NoError(t, err)
+	assert.Equal(t, machinery.ActionCreated, res.Action())
+
+	// Externally bump the revision annotation to "4".
+	err = Client.Patch(ctx,
+		configMap.DeepCopy(),
+		client.RawPatch(machinerytypes.MergePatchType, []byte(
+			`{"metadata":{"annotations":{"`+systemPrefix+`/revision":"4"}}}`,
+		)),
+	)
+	require.NoError(t, err)
+
+	// Reconcile revision 1 again — we're still the controller,
+	// so the comparator detects the annotation drift as a conflict
+	// (external field manager changed our field) and we recover.
+	res, err = oe.Reconcile(ctx, 1, configMap, types.WithOwner(owner, os))
+	require.NoError(t, err)
+	assert.Equal(t, machinery.ActionRecovered, res.Action())
+
+	// Verify the revision annotation is back to "1" on the cluster.
+	actual := &unstructured.Unstructured{}
+	actual.SetGroupVersionKind(configMap.GroupVersionKind())
+	require.NoError(t, Client.Get(ctx, client.ObjectKeyFromObject(configMap), actual))
+	assert.Equal(t, "1", actual.GetAnnotations()[systemPrefix+"/revision"])
+
+	// Cleanup.
+	gone, err := oe.Teardown(ctx, 1, configMap, types.WithOwner(owner, os))
+	require.NoError(t, err)
+	assert.False(t, gone)
+
+	gone, err = oe.Teardown(ctx, 1, configMap, types.WithOwner(owner, os))
+	require.NoError(t, err)
+	assert.True(t, gone)
+}
+
 func TestObjectEnginePaused(t *testing.T) {
 	os := ownerhandling.NewNative(Scheme)
 	comp := machinery.NewComparator(DiscoveryClient, Scheme, fieldOwner)

--- a/test/objects_test.go
+++ b/test/objects_test.go
@@ -28,10 +28,10 @@ func TestObjectEngine(t *testing.T) {
 
 	ctx := t.Context()
 	owner := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "ConfigMap",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "oe-owner",
 				"namespace": "default",
 			},
@@ -45,14 +45,14 @@ func TestObjectEngine(t *testing.T) {
 	})
 
 	configMap := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "ConfigMap",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "oe-test",
 				"namespace": "default",
 			},
-			"data": map[string]interface{}{
+			"data": map[string]any{
 				"test1": "test",
 				"test2": "test",
 			},
@@ -153,10 +153,10 @@ func TestObjectEngine_IsControllerRevisionAnnotationDrift(t *testing.T) {
 
 	ctx := t.Context()
 	owner := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "ConfigMap",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "oe-rev-drift-owner",
 				"namespace": "default",
 			},
@@ -166,14 +166,14 @@ func TestObjectEngine_IsControllerRevisionAnnotationDrift(t *testing.T) {
 	cleanupOnSuccess(t, owner)
 
 	configMap := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "ConfigMap",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "oe-rev-drift-test",
 				"namespace": "default",
 			},
-			"data": map[string]interface{}{
+			"data": map[string]any{
 				"key": "value",
 			},
 		},
@@ -225,10 +225,10 @@ func TestObjectEnginePaused(t *testing.T) {
 
 	ctx := t.Context()
 	owner := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "ConfigMap",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "oe-owner-paused",
 				"namespace": "default",
 			},
@@ -242,14 +242,14 @@ func TestObjectEnginePaused(t *testing.T) {
 	})
 
 	configMap := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "ConfigMap",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "oe-test-paused",
 				"namespace": "default",
 			},
-			"data": map[string]interface{}{
+			"data": map[string]any{
 				"test1": "test",
 				"test2": "test",
 			},
@@ -345,10 +345,10 @@ func TestObjectEngineProbing(t *testing.T) {
 
 	ctx := t.Context()
 	owner := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "ConfigMap",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "oe-owner-probing",
 				"namespace": "default",
 			},
@@ -366,14 +366,14 @@ func TestObjectEngineProbing(t *testing.T) {
 	probeUnknown := &stubProbe{status: types.ProbeStatusUnknown, messages: []string{"no clue!"}}
 
 	configMap := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "ConfigMap",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "oe-test-probing",
 				"namespace": "default",
 			},
-			"data": map[string]interface{}{
+			"data": map[string]any{
 				"test1": "test",
 				"test2": "test",
 			},
@@ -461,14 +461,14 @@ func TestObjectEngine_StaleManagedFieldMigration(t *testing.T) {
 	ctx := t.Context()
 
 	configMap := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "ConfigMap",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "oe-test-migrate",
 				"namespace": "default",
 			},
-			"data": map[string]interface{}{
+			"data": map[string]any{
 				"key": "value",
 			},
 		},

--- a/test/revision_engine_collision_protection_test.go
+++ b/test/revision_engine_collision_protection_test.go
@@ -133,6 +133,68 @@ func TestCollisionProtectionPreventOwned(t *testing.T) {
 	}
 }
 
+// TestCollisionProtectionHigherRevisionDoesNotAdoptForeignObject is a
+// regression test for https://github.com/package-operator/boxcutter/pull/501.
+// Before that PR, reconciling at a higher revision than a foreign object
+// would silently adopt it. This test ensures that an object controlled by
+// an unknown (non-sibling) owner reports a collision regardless of revision.
+func TestCollisionProtectionHigherRevisionDoesNotAdoptForeignObject(t *testing.T) {
+	ctx := logr.NewContext(t.Context(), testr.New(t))
+
+	foreignOwner := newConfigMap("test-no-adopt-foreign-foreign-owner", map[string]string{})
+	require.NoError(t, Client.Create(ctx, foreignOwner))
+	cleanupOnSuccess(t, foreignOwner)
+
+	existing := newConfigMap("test-no-adopt-foreign-cm", map[string]string{
+		"banana": "bread",
+	})
+	require.NoError(t, controllerutil.SetControllerReference(foreignOwner, existing, Scheme))
+	existing.Annotations = map[string]string{
+		systemPrefix + "/revision": "1",
+	}
+	existing.Labels = map[string]string{
+		"app.kubernetes.io/managed-by": "boxcutter.test",
+	}
+	require.NoError(t, Client.Create(ctx, existing))
+	cleanupOnSuccess(t, existing)
+
+	owner := newConfigMap("test-no-adopt-foreign-owner", map[string]string{})
+	require.NoError(t, Client.Create(ctx, owner))
+	cleanupOnSuccess(t, owner)
+
+	desired := newConfigMap("test-no-adopt-foreign-cm", map[string]string{
+		"banana": "bread",
+		"apple":  "pie",
+	})
+
+	re := newTestRevisionEngineBuilder().build(t)
+	res, err := re.Reconcile(ctx, boxcutter.NewRevisionWithOwner(
+		"test-no-adopt-foreign", 4,
+		[]boxcutter.Phase{
+			boxcutter.NewPhase(
+				"simple",
+				[]client.Object{toUns(desired)},
+			),
+		},
+		owner, ownerhandling.NewNative(Scheme),
+	))
+	require.NoError(t, err)
+	assert.False(t, res.IsComplete())
+	assert.True(t, res.InTransition())
+
+	phases := res.GetPhases()
+	require.Len(t, phases, 1)
+	objects := phases[0].GetObjects()
+	require.Len(t, objects, 1)
+	assert.Equal(t, machinery.ActionCollision, objects[0].Action())
+
+	actual := &corev1.ConfigMap{}
+	require.NoError(t, Client.Get(ctx, client.ObjectKeyFromObject(existing), actual))
+	assert.Equal(t, existing.Data, actual.Data, "object must not be modified")
+	assert.Equal(t, "1", actual.Annotations[systemPrefix+"/revision"], "revision must not change")
+	assertController(t, actual, foreignOwner.UID)
+}
+
 // TestCollisionProtectionNotInCache exercises collision protection when the
 // object exists on the cluster but is not in the (label-filtered) cache.
 func TestCollisionProtectionNotInCache(t *testing.T) {

--- a/test/revision_engine_sibling_owner_test.go
+++ b/test/revision_engine_sibling_owner_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package boxcutter
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"pkg.package-operator.run/boxcutter"
+	"pkg.package-operator.run/boxcutter/machinery"
+	"pkg.package-operator.run/boxcutter/machinery/types"
+	"pkg.package-operator.run/boxcutter/ownerhandling"
+)
+
+func TestSiblingOwnerClassifier(t *testing.T) {
+	tests := []struct {
+		name             string
+		siblingRevision  string // revision annotation on the pre-existing object
+		desiredRevision  int64  // revision we reconcile with
+		expectedAction   machinery.Action
+		expectComplete   bool
+		expectTransition bool
+		expectAdopted    bool // if true, verify controller ref changed to current owner
+	}{
+		{
+			name:             "sibling at higher revision reports progressed",
+			siblingRevision:  "4",
+			desiredRevision:  1,
+			expectedAction:   machinery.ActionProgressed,
+			expectComplete:   true,
+			expectTransition: false,
+			expectAdopted:    false,
+		},
+		{
+			name:             "sibling at lower revision triggers adoption",
+			siblingRevision:  "1",
+			desiredRevision:  2,
+			expectedAction:   machinery.ActionUpdated,
+			expectComplete:   true,
+			expectTransition: false,
+			expectAdopted:    true,
+		},
+		{
+			name:             "sibling at same revision reports collision",
+			siblingRevision:  "1",
+			desiredRevision:  1,
+			expectedAction:   machinery.ActionCollision,
+			expectComplete:   false,
+			expectTransition: true,
+			expectAdopted:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := logr.NewContext(t.Context(), testr.New(t))
+			prefix := "test-sibling-" + strings.ReplaceAll(strings.ToLower(tc.name), " ", "-") + "-"
+
+			siblingOwner := newConfigMap(prefix+"sibling-owner", map[string]string{})
+			require.NoError(t, Client.Create(ctx, siblingOwner))
+			cleanupOnSuccess(t, siblingOwner)
+
+			currentOwner := newConfigMap(prefix+"current-owner", map[string]string{})
+			require.NoError(t, Client.Create(ctx, currentOwner))
+			cleanupOnSuccess(t, currentOwner)
+
+			existing := newConfigMap(prefix+"cm", map[string]string{
+				"banana": "bread",
+			})
+			require.NoError(t, controllerutil.SetControllerReference(siblingOwner, existing, Scheme))
+			existing.Annotations = map[string]string{
+				systemPrefix + "/revision": tc.siblingRevision,
+			}
+			existing.Labels = map[string]string{
+				"app.kubernetes.io/managed-by": "boxcutter.test",
+			}
+			require.NoError(t, Client.Create(ctx, existing))
+			cleanupOnSuccess(t, existing)
+
+			desired := newConfigMap(prefix+"cm", map[string]string{
+				"banana": "bread",
+				"apple":  "pie",
+			})
+
+			re := newTestRevisionEngineBuilder().build(t)
+			res, err := re.Reconcile(ctx, boxcutter.NewRevisionWithOwner(
+				prefix+"rev", tc.desiredRevision,
+				[]boxcutter.Phase{
+					boxcutter.NewPhase(
+						"simple",
+						[]client.Object{toUns(desired)},
+					).WithReconcileOptions(
+						types.WithSiblingOwnerClassifier(func(ref metav1.OwnerReference) bool {
+							return ref.UID == siblingOwner.UID
+						}),
+					),
+				},
+				currentOwner, ownerhandling.NewNative(Scheme),
+			))
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectComplete, res.IsComplete(), "IsComplete")
+			assert.Equal(t, tc.expectTransition, res.InTransition(), "InTransition")
+
+			phases := res.GetPhases()
+			require.Len(t, phases, 1)
+			objects := phases[0].GetObjects()
+			require.Len(t, objects, 1)
+			assert.Equal(t, tc.expectedAction, objects[0].Action())
+
+			actual := &corev1.ConfigMap{}
+			require.NoError(t, Client.Get(ctx, client.ObjectKeyFromObject(existing), actual))
+
+			if tc.expectAdopted {
+				assert.Equal(t, "pie", actual.Data["apple"], "adopted object should have new data")
+				assert.Equal(t, tc.desiredRevision, mustParseRevision(t, actual), "revision annotation should be updated")
+				assertController(t, actual, currentOwner.UID)
+			} else {
+				assert.Equal(t, existing.Data, actual.Data, "object should not be modified")
+				assert.Equal(t, tc.siblingRevision, actual.Annotations[systemPrefix+"/revision"], "revision annotation should be unchanged")
+				assertController(t, actual, siblingOwner.UID)
+			}
+		})
+	}
+}
+
+func mustParseRevision(t *testing.T, obj *corev1.ConfigMap) int64 {
+	t.Helper()
+
+	raw := obj.Annotations[systemPrefix+"/revision"]
+	require.NotEmpty(t, raw, "revision annotation missing")
+
+	rev, err := strconv.ParseInt(raw, 10, 64)
+	require.NoError(t, err)
+
+	return rev
+}
+
+func assertController(t *testing.T, obj *corev1.ConfigMap, expectedUID apitypes.UID) {
+	t.Helper()
+
+	for _, ref := range obj.OwnerReferences {
+		if ref.Controller != nil && *ref.Controller {
+			assert.Equal(t, expectedUID, ref.UID, "controller UID should match expected owner")
+
+			return
+		}
+	}
+
+	t.Errorf("no controller owner reference found on object %s/%s", obj.Namespace, obj.Name)
+}


### PR DESCRIPTION
## Replace `WithPreviousOwners` with `WithSiblingOwnerClassifier`                                                                                                       
                                       
### Problem                                                                                                                                                             
 
The current `WithPreviousOwners` API only accepts backward references — owners from lower revisions. This creates a fundamental tension:                                
                                                          
- **Collision protection** (PR #501's goal): When an unknown controller owns an object, we want to detect and report it as a collision rather than silently taking over.
- **Revision progression**: When a *newer* revision has already adopted an object, the older revision should recognize this as "progressed," not a collision.
                                                                                                                                                                        
`WithPreviousOwners` can't satisfy both requirements. A lower revision doesn't know about higher revisions, so after a newer revision adopts objects, the older revision
 sees an unknown controller and reports `ActionCollision` — a false positive that breaks controllers built on top of the phase engine.                                  
                                                                                                                                                                        
### Proposal                                              

Replace `WithPreviousOwners` with `WithSiblingOwnerClassifier` — a callback that classifies whether a given controller is a sibling revision of the same deployment or a
 genuinely unknown controller and rely on revision annotation on managed object to decide if it is managed by a previous or future revision.
                                                                                                                                                                        
This decouples the concept from directionality. Clients pass **all** sibling revisions (both previous and future), giving the `ObjectEngine` enough information to      
distinguish:
                                                                                                                                                                        
| Controller is... | Result |                             
|---|---|
| Us | Normal reconcile (idle/updated/recovered) |
| A known sibling with higher revision | `ActionProgressed` |                                                                                                           
| A known sibling with lower revision | Adoption (take ownership) |                                                                                                     
| An unknown controller | `ActionCollision` (with collision protection) |                                                                                               
                                                                                                                                                                        
### API Changes                                           
                                                                                                                                                                        
```go                                                     
// Before
WithPreviousOwners(previous []client.Object) ObjectReconcileOption
                                                                                                                                                                        
// After
WithSiblingOwnerClassifier struct {                                                                                                                                     
    Classifier SiblingOwnerClassifierFunc // func(ownerRef metav1.OwnerReference) bool
}

// Convenience constructors
WithSiblingOwners(siblings []client.Object) WithSiblingOwnerClassifier
WithSiblingOwnerRefs(ownerRefs []metav1.OwnerReference) WithSiblingOwnerClassifier                                                                                      

// Convenience constructors with owner built in:                                                                                                                                                                                  
NewPhaseWithOwnerAndSiblings(name, objects, owner, ownerStrat, siblings)                                                                                                
NewRevisionWithOwnerAndSiblings(name, revNumber, phases, owner, ownerStrat, siblings)
```
                                                                              
### Breaking Change
                                                                                                                                                                        
WithPreviousOwners is removed. Clients must migrate to WithSiblingOwnerClassifier or one of its convenience constructors.                                               
 
#### Migration: operator-controller                                                                                                                                          
                                                          
operator-controller uses WithPreviousOwners in clusterobjectset_controller.go:474. The listPreviousRevisions method already lists all sibling ClusterObjectSet revisions by owner label but filters to r.Spec.Revision < cos.Spec.Revision.
                                                                                                                                                                        
Steps:                                                    

1. In listPreviousRevisions (or a new listSiblingRevisions): replace the filter with `r.Spec.Revision != cos.Spec.Revision` filter so it returns siblings in both directions — keep the archived/deleting filters.
2. Replace `boxcutter.WithPreviousOwners(previousObjs)` with `boxcutter.WithSiblingOwners(siblingObjs)`.                                                                    
                                                                                                                                                                        
#### Migration: cluster-capi-operator
                                                                                                                                                                        
cluster-capi-operator does not use `WithPreviousOwners` at all. It calls `revisionEngine.Reconcile` and `revisionEngine.Teardown` without any previous/sibling owner options. 
No migration needed — the removal of `WithPreviousOwners` does not affect this project.

### Change Type

<!-- Uncomment one of the following -->
Breaking Change
New Feature
Bug Fix
Docs/Test

### Check List Before Merging

- [ ] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] Relevant documentation has been updated.

### Additional Information

<!-- Report any other relevant details below -->
