### PR TITLE
fix: HasProgressed returns false when phase has validation error

### DIFF
--- a/machinery/phases.go
+++ b/machinery/phases.go
@@ -303,6 +303,10 @@ func (r *phaseResult) InTransition() bool {
 
 // HasProgressed returns true when all objects have been progressed to a newer revision.
 func (r *phaseResult) HasProgressed() bool {
+	if r.GetValidationError() != nil {
+		return false
+	}
+
 	var numProgressed int
 
 	for _, o := range r.objects {

--- a/machinery/phases_test.go
+++ b/machinery/phases_test.go
@@ -412,6 +412,57 @@ func TestPhaseResult(t *testing.T) {
 		}
 	})
 
+	t.Run("HasProgressed", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			pv       *validation.PhaseValidationError
+			res      []ObjectResult
+			expected bool
+		}{
+			{
+				name: "true - all progressed",
+				res: []ObjectResult{
+					newObjectResultProgressed(nil, CompareResult{}, types.ObjectReconcileOptions{}),
+				},
+				expected: true,
+			},
+			{
+				name:     "true - empty",
+				res:      []ObjectResult{},
+				expected: true,
+			},
+			{
+				name: "false - preflight violation",
+				pv: &validation.PhaseValidationError{
+					PhaseName:  "xxx",
+					PhaseError: errTest,
+				},
+				res:      []ObjectResult{},
+				expected: false,
+			},
+			{
+				name: "false - not progressed",
+				res: []ObjectResult{
+					newObjectResultCreated(nil, types.ObjectReconcileOptions{}),
+				},
+				expected: false,
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
+
+				pr := &phaseResult{
+					validationError: test.pv,
+					objects:         test.res,
+				}
+				assert.Equal(t, test.expected, pr.HasProgressed())
+			})
+		}
+	})
+
 	t.Run("IsComplete", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
IsComplete and InTransition both return false early when a phase has
a validation error, but HasProgressed was missing the same guard.
A phase with a validation error has no objects, so HasProgressed
evaluated 0 == 0 and returned true, incorrectly reporting the phase
as progressed. This could cause revisionResult.HasProgressed to
report a revision as fully progressed when it has unresolved
validation errors.