### PR TITLE
fix: recognize NoMatchError as DryRunValidationError

### DIFF
--- a/validation/object.go
+++ b/validation/object.go
@@ -193,6 +193,9 @@ func validateDryRun(
 	case err == nil:
 		return nil
 
+	case meta.IsNoMatchError(err):
+		return DryRunValidationError{err: err}
+
 	case errors.As(err, &apiErr):
 		switch apiErr.Status().Reason {
 		case metav1.StatusReasonUnauthorized,

--- a/validation/object_test.go
+++ b/validation/object_test.go
@@ -536,6 +536,28 @@ func TestValidateDryRun(t *testing.T) {
 			expectDryRunValError: true,
 		},
 		{
+			name: "NoMatchError from REST mapper",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "fake.example.com/v1",
+					"kind":       "Nonexistent",
+					"metadata": map[string]any{
+						"name":      "test",
+						"namespace": "default",
+					},
+				},
+			},
+			mockSetup: func(writer *mockWriter) {
+				writer.On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+					&meta.NoKindMatchError{
+						GroupKind:        schema.GroupKind{Group: "fake.example.com", Kind: "Nonexistent"},
+						SearchedVersions: []string{"v1"},
+					})
+			},
+			expectError:          true,
+			expectDryRunValError: true,
+		},
+		{
 			name: "non-API status error",
 			obj: &unstructured.Unstructured{
 				Object: map[string]any{


### PR DESCRIPTION
When the REST mapper returns a NoMatchError (e.g., a CRD is not
installed on the cluster), dryRunValidate treated it as an unexpected
error. This caused the phase engine to return a reconcile error
instead of a structured validation result.

Handle NoMatchError as a DryRunValidationError so that missing APIs
are reported as validation failures, allowing the phase to continue
reconciling other objects in the same phase.