### PR TITLE
fix: retry SSA field manager migration on conflict

### DIFF
--- a/machinery/objects.go
+++ b/machinery/objects.go
@@ -14,6 +14,7 @@ import (
 	machinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/csaupgrade"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -673,24 +674,38 @@ func (e *ObjectEngine) migrateFieldManagersToSSA(
 		return nil
 	}
 
-	patch, err := csaupgrade.UpgradeManagedFieldsPatch(
-		object, sets.New(e.fieldOwner), e.fieldOwner)
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := e.refreshObject(ctx, object); err != nil {
+			return fmt.Errorf("re-getting object: %w", err)
+		}
 
-	switch {
-	case err != nil:
-		return err
-	case len(patch) == 0:
-		// csaupgrade.UpgradeManagedFieldsPatch returns nil, nil when no work is to be done.
-		// Empty patch cannot be applied so exit early.
+		patch, err := csaupgrade.UpgradeManagedFieldsPatch(
+			object, sets.New(e.fieldOwner), e.fieldOwner)
+
+		switch {
+		case err != nil:
+			return err
+		case len(patch) == 0:
+			// csaupgrade.UpgradeManagedFieldsPatch returns nil, nil when no work is to be done.
+			// Empty patch cannot be applied so exit early.
+			return nil
+		}
+
+		if err := e.writer.Patch(ctx, object, client.RawPatch(machinerytypes.JSONPatchType, patch)); err != nil {
+			return fmt.Errorf("update field managers: %w", err)
+		}
+
 		return nil
+	})
+}
+
+func (e *ObjectEngine) refreshObject(ctx context.Context, object Object) error {
+	reader := e.cache
+	if e.unfilteredReader != nil {
+		reader = e.unfilteredReader
 	}
 
-	if err := e.writer.Patch(ctx, object, client.RawPatch(
-		machinerytypes.JSONPatchType, patch)); err != nil {
-		return fmt.Errorf("update field managers: %w", err)
-	}
-
-	return nil
+	return reader.Get(ctx, client.ObjectKeyFromObject(object), object)
 }
 
 func (e *ObjectEngine) revisionAnnotation() string {

--- a/machinery/objects_test.go
+++ b/machinery/objects_test.go
@@ -236,7 +236,13 @@ func TestObjectEngine(t *testing.T) {
 					On("Get", mock.Anything,
 						client.ObjectKey{Name: "testi", Namespace: "test"},
 						mock.Anything, mock.Anything).
-					Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+					Return(apierrors.NewNotFound(schema.GroupResource{}, "")).Once()
+				// Second Get is the refresh inside migrateFieldManagersToSSA.
+				cache.
+					On("Get", mock.Anything,
+						client.ObjectKey{Name: "testi", Namespace: "test"},
+						mock.Anything, mock.Anything).
+					Return(nil)
 				ddm.
 					On("Compare", mock.Anything, mock.Anything, mock.Anything).
 					Return(CompareResult{}, nil)
@@ -1729,7 +1735,13 @@ func TestObjectEngine_CustomManagedByLabel(t *testing.T) {
 		On("Get", mock.Anything,
 			client.ObjectKey{Name: "test-custom-managed-by", Namespace: "test"},
 			mock.Anything, mock.Anything).
-		Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+		Return(apierrors.NewNotFound(schema.GroupResource{}, "")).Once()
+	// Second Get is the refresh inside migrateFieldManagersToSSA.
+	cache.
+		On("Get", mock.Anything,
+			client.ObjectKey{Name: "test-custom-managed-by", Namespace: "test"},
+			mock.Anything, mock.Anything).
+		Return(nil)
 	divergeDetector.
 		On("Compare", mock.Anything, mock.Anything, mock.Anything).
 		Return(CompareResult{}, nil)
@@ -1779,18 +1791,6 @@ func TestObjectEngine_GetObjectRevision_Error(t *testing.T) {
 func TestObjectEngine_MigrateFieldManagersToSSA_NoPatch(t *testing.T) {
 	t.Parallel()
 
-	writer := testutil.NewClient()
-	oe := NewObjectEngine(
-		scheme.Scheme,
-		testutil.NewClient(),
-		writer,
-		&comparatorMock{},
-		testFieldOwner,
-		testSystemPrefix,
-		"",
-		nil,
-	)
-
 	obj := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "v1",
@@ -1801,6 +1801,27 @@ func TestObjectEngine_MigrateFieldManagersToSSA_NoPatch(t *testing.T) {
 			},
 		},
 	}
+
+	cache := testutil.NewClient()
+	cache.
+		On("Get", mock.Anything, client.ObjectKeyFromObject(obj), mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			out := args.Get(2).(*unstructured.Unstructured)
+			*out = *obj
+		}).
+		Return(nil)
+
+	writer := testutil.NewClient()
+	oe := NewObjectEngine(
+		scheme.Scheme,
+		cache,
+		writer,
+		&comparatorMock{},
+		testFieldOwner,
+		testSystemPrefix,
+		"",
+		nil,
+	)
 
 	err := oe.migrateFieldManagersToSSA(context.Background(), obj, types.ObjectReconcileOptions{})
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- After creating an object, `migrateFieldManagersToSSA` patches the field managers to be SSA-compatible using `csaupgrade`. If another controller (e.g. the `apiextensions` controller updating CRD status) modifies the object between the create response and that patch, the API server rejects the patch with a 409 Conflict due to a stale `resourceVersion`.
- Wraps the patch attempt in `retry.RetryOnConflict(retry.DefaultBackoff, ...)`. `DefaultBackoff` uses exponential backoff (factor 5×), which is the correct choice for conflicts caused by an unrelated controller — as opposed to `DefaultRetry` (linear), which is for multiple clients racing on the same resource. On conflict, the object is re-fetched (via `unfilteredReader` if available, otherwise `cache`) to get the latest `resourceVersion` before recomputing and re-applying the patch.
- Extracts a small `refreshObject` helper used by the retry closure, called unconditionally at the top of each iteration.

## Motivation

Users were seeing transient errors of the form:
```
reconciling object: reconciling apiextensions.k8s.io/v1, Kind=CustomResourceDefinition /applications.argoproj.io: migrating to SSA after create: update field managers: Operation cannot be fulfilled on customresourcedefinitions.apiextensions.k8s.io "applications.argoproj.io": the object has been modified; please apply your changes to the latest version and try again
```

This is a TOCTOU race that is especially common with CRDs because the `apiextensions` controller patches status immediately after creation. The retry absorbs the transient conflict without any user-visible error.

## Test plan

- [ ] Existing unit tests pass (`./do dev:unit`)
- [ ] Manual verification: reconcile a CRD-backed object and confirm the error no longer surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)